### PR TITLE
chore(release): v0.0.1 — Phase 0 bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,30 +6,53 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-### Added
-- Quarkus application bootstraps cleanly with liveness/readiness/started probes under `/q/health*`, aggregate health at `/q/health`, OpenAPI at `/q/openapi`, and Swagger UI at `/q/swagger-ui`.
-- `GET /` service metadata endpoint returning name, version, and well-known endpoint paths.
-- Runtime config in `backend/app/src/main/resources/application.yml` with `default`, `%dev`, `%test`, `%prod` profiles.
-- CDI bean discovery via `META-INF/beans.xml` in every backend module so resources declared in sibling modules are discovered.
-- Test coverage for health probes, index endpoint, and OpenAPI reachability (`HealthAndIndexIT`, 6 tests).
+_Nothing yet._
 
-### Infrastructure
-- Elytron LDAP extension placeholder values in default profile so the app boots without LDAP configured (Phase 7 wires real values).
-- Dev-services disabled in `%test` profile; tests that need Postgres / LocalStack will opt in explicitly (Phase 1+).
+## [0.0.1] — 2026-04-17 — Phase 0: Bootstrap
 
-## [0.0.1] — 2026-04-16 — Phase 0: Bootstrap
+First prerelease. The repository, CI surface, and runtime pipeline exist end-to-end; no product features yet. Next release (v0.1.0, Phase 1) lights up auth and the org / project model.
 
 ### Added
-- Repository scaffolding: top-level files (README, LICENSE, CHANGELOG, RELEASE-NOTES, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, CODEOWNERS).
-- `.github/` workflows skeleton (ci-backend, ci-webapp, ci-e2e, link-checker, codeql, release, pages, dependabot).
-- `.kiro/steering/` always-loaded steering files (architecture, contributing-rules, api-conventions, ui-conventions).
-- `CLAUDE.md`, `AGENTS.md`, `.claude/commands/` for AI-pair-programming context.
-- Gradle Kotlin DSL multi-module skeleton (`backend/`).
-- Webapp skeleton (Vite + React + TypeScript + Tailwind + shadcn/ui placeholder).
-- `infra/` with `docker-compose.yml` (Postgres 16, Redis 7, MinIO, Mailpit) and Dockerfile placeholders.
-- Read-only third-party reference sources under `_reference/` (gitignored).
-- `tasks.md` and `_progress.md` Kiro-style trackers.
-- MIT LICENSE.
+
+**Repository & governance**
+- Top-level files: `README.md`, `LICENSE` (MIT), `CHANGELOG.md`, `RELEASE-NOTES.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CODEOWNERS`.
+- Agent-pair-programming context: `CLAUDE.md`, `AGENTS.md`, `.claude/commands/` (`/new-phase`, `/release`, `/check-pr`, `/dogfood-strings`).
+- Always-loaded Kiro steering: `.kiro/steering/architecture.md`, `contributing-rules.md`, `api-conventions.md`, `ui-conventions.md`.
+- Kiro-style trackers: `tasks.md` (T001–T713) and `_progress.md` (phase dashboard + weekly log).
+- Branch protection on `master`: PR required, CODEOWNERS review, signed commits, linear history, no force push / deletions.
+- 97 GitHub issues seeded across 8 phase milestones with `type:*` / `scope:*` / `est:*` labels and an MVP partition (`mvp` / `post-mvp` / `deferred`).
+
+**CI / CD**
+- `.github/workflows/`: `ci-backend`, `ci-webapp`, `link-checker` (lychee), `codeql` (java-kotlin + javascript-typescript + actions), `release`, `pages`, Dependabot.
+- Issue templates (`bug.yml`, `feature.yml`, `question.yml`), PR template with 14-point pre-merge checklist.
+
+**Backend (Quarkus · Kotlin · Java 21)**
+- Gradle (Kotlin DSL) multi-module skeleton: `backend/{api,data,service,security,jobs,ai,mt,storage,email,webhooks,cdn,audit,app}` with convention plugins (`translately.base`, `translately.quarkus-module`, `translately.quarkus-app`).
+- Version catalog at `gradle/libs.versions.toml` pinning Kotlin 2.1 · Quarkus 3.17 · Kotest / MockK / Testcontainers / ArchUnit.
+- Runtime: Quarkus application boots, serves `GET /` (service metadata), `/q/health/{live,ready,started}`, `/q/openapi`, `/q/swagger-ui`. 6 @QuarkusTest assertions.
+- CDI bean discovery via `META-INF/beans.xml` in every backend module.
+- LDAP extension placeholder values in the default profile so the app boots without LDAP configured (Phase 7 wires real values).
+
+**Webapp (React · Vite · TypeScript · Tailwind · shadcn)**
+- pnpm workspace + Vite 6 + React 18 + TS 5.7 strict.
+- Design tokens for light + dark in `src/theme/tokens.css`; hsl-var references; honors `prefers-reduced-motion`; persistent focus rings.
+- `ThemeProvider` + `ThemeToggle` cycling light → dark → system with `localStorage` persistence and OS-preference reactivity.
+- shadcn primitive: `Button` (6 variants × 4 sizes × `asChild`).
+- Lucide icons only; `src/i18n/` dogfood wrapper with `en.json`.
+- App shell: header/main/footer landmarks, primary nav, metric cards, MVP summary.
+- 55 tests across 6 suites (`utils.test.ts`, `i18n.test.ts`, `button.test.tsx`, `ThemeProvider.test.tsx`, `ThemeToggle.test.tsx`, `App.test.tsx`) — all green, no axe violations in light or dark.
+
+**Infra**
+- `docker-compose.yml` for dev: Postgres 16, Redis 7, MinIO (auto-created buckets), Mailpit; Keycloak behind `--profile keycloak`.
+- `infra/docker/`: `backend.Dockerfile` (JVM fast-jar), `backend.native.Dockerfile` (GraalVM native-image), `webapp.Dockerfile` (nginx static + SPA + `/api` reverse proxy), `nginx.conf`.
+- `infra/compose-prod.yml` + `.env.prod.example` for single-host production.
+- `docs/` landing page + `self-hosting/hardening.md` placeholder.
+
+### Notes
+
+- No paywalled premium tier: every planned feature (SSO, SAML, LDAP, Tasks, Branching, Webhooks, Glossaries, custom storage, granular permissions, audit) will ship MIT.
+- AI is bring-your-own-key, entirely optional. The platform must work end-to-end with zero AI configured.
+- Third-party reference sources under `_reference/` are read-only, AGPL-licensed, gitignored, never copied.
 
 [Unreleased]: https://github.com/Pratiyush/translately/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/Pratiyush/translately/releases/tag/v0.0.1

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,29 +6,54 @@ Long-form release narratives. For raw diffs and per-PR detail, see [CHANGELOG.md
 
 ## v0.0.1 — Phase 0: Bootstrap
 
-**Released:** 2026-04-16
+**Released:** 2026-04-17
 **Status:** prerelease
+**Tag:** `v0.0.1` (GPG-signed) · [Compare with master](https://github.com/Pratiyush/translately/compare/v0.0.1...master)
 
 ### What's in the box
 
-This is the seed commit for Translately — an open-source, MIT-licensed localization platform with bring-your-own-key AI. Nothing runs yet; this release exists to nail down the structure, conventions, and tooling before any business logic lands.
+This is the seed prerelease for Translately — an open-source, MIT-licensed, self-hosted localization and translation management platform with bring-your-own-key AI. No product features yet; v0.0.1 exists to nail down the structure, conventions, CI, and runtime pipeline before any business logic ships.
 
-- Multi-module Gradle Kotlin DSL backend (Quarkus + Kotlin + Java 21).
-- Webapp scaffold (React + Vite + TypeScript + Tailwind + shadcn/ui).
-- Local infrastructure via `docker-compose up`: PostgreSQL 16, Redis 7, MinIO, Mailpit.
-- CI workflows for backend, webapp, e2e, security scans, link checks, docs deploy, release pipeline.
-- Kiro steering files documenting architecture, API conventions, UI conventions, and contribution rules.
-- Read-only third-party reference sources under `_reference/` (gitignored) for design inspiration only.
+**What actually runs**
+
+- **Backend.** Quarkus 3.17 on Kotlin / Java 21. `./gradlew :backend:app:quarkusDev` starts the app; probes respond at `/q/health/{live,ready,started}`, aggregate health at `/q/health`, OpenAPI at `/q/openapi`, Swagger UI at `/q/swagger-ui`. A `GET /` service-metadata endpoint returns name, version, and well-known paths.
+- **Webapp.** `pnpm --filter @translately/webapp dev` boots a Vite + React + TypeScript + Tailwind app with a shadcn-style Button primitive, a working light/dark/system theme toggle (localStorage + OS reactivity), Lucide icons, and a dogfood `i18n.t()` wrapper backed by `en.json`.
+- **Infra.** `docker compose up -d` starts Postgres 16, Redis 7, MinIO (with auto-created buckets), and Mailpit. Keycloak is available behind `--profile keycloak`.
+
+**Quality gates**
+
+- 6 backend `@QuarkusTest` assertions cover health + index + OpenAPI reachability.
+- 55 webapp tests across 6 suites cover the `cn()` helper, i18n lookup, the Button primitive, the ThemeProvider + ThemeToggle, and App shell structure + interaction. **`axe-core` reports zero violations in light AND dark.**
+- CI runs on every push + PR: `ci-backend` (Gradle build + ktlint + detekt + test + JaCoCo), `ci-webapp` (pnpm lint + test + build), `lychee` link-checker, `codeql` (java-kotlin + javascript-typescript + actions).
+
+**Governance**
+
+- Master branch protected: PR required, CODEOWNERS review, signed commits, linear history, no force push / deletions, conversation resolution.
+- 97 GitHub issues seeded across 8 phase milestones with `type:*` / `scope:*` / `est:*` labels. MVP partition applied: 57 `mvp` (Phases 0–3), 37 `post-mvp` (Phases 4–7), 3 `deferred` (Figma plugin, MCP server, migration importer).
+- Dependabot configured for Gradle, npm workspaces, GitHub Actions, Docker.
 
 ### Migration notes
 
-None — first release.
+None — first prerelease. Nothing to migrate from.
 
 ### Known limitations
 
-- No working features yet. The next release (v0.1.0) brings auth + organizations + projects.
-- Backend and webapp build and boot, but only return placeholder responses.
+- No product features. No auth, no organizations, no keys, no translations. Those land in v0.1.0 and v0.2.0.
+- Backend depends on the Phase 7 LDAP extension at build time, so the default profile ships with inert LDAP placeholder config. Real wiring comes in Phase 7.
+- Webapp does not yet dogfood against a live Translately project — `t()` resolves locally from `en.json` until the JS SDK lands in Phase 5.
+- Release images (`ghcr.io/pratiyush/translately-backend`, `-webapp`) are NOT published for `v0.0.1`. The `release.yml` Docker job is gated to skip on this version because the fast-jar doesn't yet have product binary shape. Images start publishing at `v0.1.0`.
 
-### What's next
+### What's next — Phase 1 → v0.1.0
 
-Phase 1 → v0.1.0: Email+password signup, JWT, optional Keycloak OIDC profile, Google OAuth, organizations, projects, languages, API keys, project member RBAC, and a webapp shell with login/signup/org-picker/project-list.
+- Email + password signup with email verification (via Mailpit in dev).
+- JWT access + refresh token rotation (Smallrye JWT).
+- Google OAuth; optional Keycloak OIDC profile.
+- Entities: `User`, `Organization`, `OrganizationMember`, `Project`, `ProjectLanguage`, `ApiKey`, `Pat`.
+- Permission scope enum + `@RequiresScope` annotation + org / project RBAC.
+- Multi-tenant `TenantRequestFilter` + Hibernate filter per-request.
+- `CryptoService` envelope encryption skeleton (for Phase 4 AI keys).
+- OpenAPI published to `docs/api/openapi.json`; webapp API client auto-generated.
+- Webapp app shell: nav, org switcher, user menu, ⌘K command palette, signup / login / org / project pages.
+- `.github/workflows/ci-e2e.yml` spinning up the full docker-compose stack and running Playwright smoke tests.
+
+Target: **2026-05-07**.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-translately.version=0.0.1-SNAPSHOT
+translately.version=0.0.1
 
 # JVM / performance
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8

--- a/lychee.toml
+++ b/lychee.toml
@@ -21,7 +21,7 @@ exclude_path = ["_reference"]
 exclude = [
     # Release tags & compare views
     '^https://github\.com/Pratiyush/translately/releases/tag/v\d+\.\d+\.\d+$',
-    '^https://github\.com/Pratiyush/translately/compare/v\d+\.\d+\.\d+\.\.\.HEAD$',
+    '^https://github\.com/Pratiyush/translately/compare/v\d+\.\d+\.\d+\.\.\.(HEAD|master|v\d+\.\d+\.\d+)$',
 
     # GitHub Pages site — deploys on first push but DNS/cache may trail
     '^https://pratiyush\.github\.io/translately/?$',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translately",
-  "version": "0.0.1-SNAPSHOT",
+  "version": "0.0.1",
   "private": true,
   "description": "Open-source, MIT-licensed, self-hosted localization and translation management platform (monorepo root).",
   "author": "Pratiyush <pratiyush1@gmail.com>",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@translately/webapp",
-  "version": "0.0.1-SNAPSHOT",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "description": "Translately webapp — React + Vite + TypeScript + Tailwind + shadcn/ui.",


### PR DESCRIPTION
## Summary

Finalizes CHANGELOG + RELEASE-NOTES for the Phase 0 prerelease and bumps version markers from `0.0.1-SNAPSHOT` to `0.0.1`.

Closes #17

## Why

Phase 0 is shipping. Per our release flow: update CHANGELOG + RELEASE-NOTES before tagging; the tag itself lands as a separate, GPG-signed operation on master (T018 / #18) once this merges.

## How

- `CHANGELOG.md` — move every Unreleased bullet under `[0.0.1] — 2026-04-17`. Add full governance / CI-CD / backend / webapp / infra sections so the entry is self-contained for readers who only consult the changelog.
- `RELEASE-NOTES.md` — long-form narrative. What runs today, quality gates (6 + 55 tests), known limitations (no product features, LDAP placeholder, Docker images skipped on this tag), and what ships in v0.1.0.
- `gradle.properties` — `translately.version=0.0.1`.
- Root `package.json` and `webapp/package.json` — `version: 0.0.1`.

## Tests

- [x] `./gradlew printVersion` → `0.0.1`.
- [x] `pnpm install` — lockfile unchanged.
- [x] Manual: CHANGELOG `[Unreleased]` is empty; `[0.0.1]` has every bullet; link references at the bottom resolve.

## Pre-merge checklist

- [x] PR is one intent (release finalization)
- [ ] All CI checks green
- [x] Linked issue closed by `Closes #17`
- [x] No migrations
- [x] `CHANGELOG.md` updated (this PR **is** the update)
- [x] No breaking change
- [x] No dependency change
- [x] No dead TODO/FIXME
- [x] N/A — no UI change
- [x] N/A — no UI change
- [x] No secrets
- [x] No queries
- [x] Commit GPG-signed, Pratiyush only
- [x] Self-reviewed every changed line