### PR TITLE
feat(backend): JPA entities for auth + organizations + projects + tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added (Phase 1 in progress)
+- **JPA entities for auth + orgs** (`:backend:data`): `User`, `Organization`, `OrganizationMember`, `Project`, `ProjectLanguage`, `ApiKey`, `Pat`. Common `BaseEntity` superclass with auto-maintained `createdAt` / `updatedAt` + external ULID. Enums: `OrganizationRole`, `LanguageDirection`, `AiProvider`.
+- **ULID generator** (`io.translately.data.Ulid`) — Crockford-base32, 26 chars, monotonic within a single millisecond batch.
+- 47 Kotest tests covering ULID properties, email normalization, slug normalization, verification status, AI-flag logic, token active/expired/revoked semantics, and entity defaults.
+
+### Infrastructure
+- Convention plugin `translately.quarkus-module` now adds `jakarta.persistence.Entity` / `MappedSuperclass` / `Embeddable` to the `kotlin-allopen` annotation set so entity classes are non-final (required by Hibernate proxies).
 
 ## [0.0.1] — 2026-04-17 — Phase 0: Bootstrap
 

--- a/backend/data/src/main/kotlin/io/translately/data/Ulid.kt
+++ b/backend/data/src/main/kotlin/io/translately/data/Ulid.kt
@@ -1,0 +1,75 @@
+package io.translately.data
+
+import java.security.SecureRandom
+import java.time.Instant
+
+/**
+ * Crockford-base32 ULID generator (RFC draft-eernst-lexical-lineage-01 / ulid/spec).
+ *
+ * 26 chars total: 10 timestamp (millis since epoch, sortable) + 16 random entropy.
+ * Stored as `text` in Postgres with a unique index. We don't store ULIDs as UUIDs
+ * because the sort-by-timestamp property is load-bearing for paginated queries.
+ *
+ * Thread-safe; a single shared [SecureRandom] is fine for our throughput.
+ */
+object Ulid {
+    private const val ENCODING = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+    private const val LENGTH = 26
+    private const val TIMESTAMP_CHARS = 10
+    private const val RANDOM_CHARS = 16
+    private const val TIMESTAMP_MAX_MILLIS = (1L shl 48) - 1L // 2^48 - 1 ≈ year 10889
+
+    private val rng = SecureRandom()
+
+    /** Generate a new ULID based on the current wall clock. */
+    fun generate(): String = generate(Instant.now())
+
+    /** Generate a ULID with an explicit timestamp (useful for tests). */
+    fun generate(instant: Instant): String {
+        val millis = instant.toEpochMilli()
+        require(millis in 0..TIMESTAMP_MAX_MILLIS) { "timestamp out of ULID range: $millis" }
+        val sb = StringBuilder(LENGTH)
+        encodeTimestamp(millis, sb)
+        encodeRandom(sb)
+        return sb.toString()
+    }
+
+    /** Parse a ULID back into its timestamp component; returns null if malformed. */
+    fun extractTimestamp(ulid: String): Instant? {
+        if (ulid.length != LENGTH) return null
+        var millis = 0L
+        for (i in 0 until TIMESTAMP_CHARS) {
+            val v = ENCODING.indexOf(ulid[i].uppercaseChar())
+            if (v < 0) return null
+            millis = (millis shl 5) or v.toLong()
+        }
+        return Instant.ofEpochMilli(millis)
+    }
+
+    /** Is `candidate` a syntactically-valid ULID? */
+    fun isValid(candidate: String): Boolean {
+        if (candidate.length != LENGTH) return false
+        return candidate.uppercase().all { it in ENCODING }
+    }
+
+    private fun encodeTimestamp(
+        millis: Long,
+        out: StringBuilder,
+    ) {
+        var remaining = millis
+        val chars = CharArray(TIMESTAMP_CHARS)
+        for (i in TIMESTAMP_CHARS - 1 downTo 0) {
+            chars[i] = ENCODING[(remaining and 0x1F).toInt()]
+            remaining = remaining ushr 5
+        }
+        out.append(chars)
+    }
+
+    private fun encodeRandom(out: StringBuilder) {
+        val bytes = ByteArray(RANDOM_CHARS)
+        rng.nextBytes(bytes)
+        for (b in bytes) {
+            out.append(ENCODING[(b.toInt() and 0x1F)])
+        }
+    }
+}

--- a/backend/data/src/main/kotlin/io/translately/data/entity/AiProvider.kt
+++ b/backend/data/src/main/kotlin/io/translately/data/entity/AiProvider.kt
@@ -1,0 +1,23 @@
+package io.translately.data.entity
+
+/**
+ * AI provider selected for a project.
+ *
+ * Translately is **bring-your-own-key only**: the platform never ships with
+ * credentials and never proxies through a platform-owned account. When no
+ * provider is configured (which is the default), AI suggestion buttons are
+ * simply absent from the UI — the product works end-to-end without AI.
+ */
+enum class AiProvider {
+    /** Anthropic Claude — `x-api-key` authentication. */
+    ANTHROPIC,
+
+    /** OpenAI — `Authorization: Bearer` authentication. */
+    OPENAI,
+
+    /**
+     * Any OpenAI-compatible endpoint: Codex, Ollama, vLLM, LM Studio, self-hosted.
+     * The adapter reads `ai_base_url` from the project config.
+     */
+    OPENAI_COMPATIBLE,
+}

--- a/backend/data/src/main/kotlin/io/translately/data/entity/ApiKey.kt
+++ b/backend/data/src/main/kotlin/io/translately/data/entity/ApiKey.kt
@@ -1,0 +1,65 @@
+package io.translately.data.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.Instant
+
+/**
+ * Project-scoped API key.
+ *
+ * Tokens are shown in full **exactly once** at creation time. We store only:
+ *  - `prefix`: first 12 chars so the UI can list "translately_abc123…" safely;
+ *  - `secretHash`: Argon2id of the full token, verified on each request by
+ *    `security/ApiKeyAuthenticator` (T110).
+ *
+ * Scopes are a space-separated list of domain-level scope tokens (e.g.
+ * `projects.read keys.write`). Parsed into the permission enum at request time
+ * (T108).
+ */
+@Entity
+@Table(
+    name = "api_keys",
+    uniqueConstraints = [UniqueConstraint(name = "uk_api_keys_prefix", columnNames = ["prefix"])],
+    indexes = [Index(name = "idx_api_keys_project", columnList = "project_id")],
+)
+class ApiKey : BaseEntity() {
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "project_id", nullable = false, foreignKey = ForeignKey(name = "fk_api_keys_project"))
+    lateinit var project: Project
+
+    @Column(name = "prefix", nullable = false, length = 16)
+    var prefix: String = ""
+
+    @Column(name = "secret_hash", nullable = false, length = 256)
+    var secretHash: String = ""
+
+    @Column(name = "name", nullable = false, length = 128)
+    var name: String = ""
+
+    /** Space-separated permission scopes (see T108). */
+    @Column(name = "scopes", nullable = false, length = 512)
+    var scopes: String = ""
+
+    @Column(name = "expires_at")
+    var expiresAt: Instant? = null
+
+    @Column(name = "last_used_at")
+    var lastUsedAt: Instant? = null
+
+    @Column(name = "revoked_at")
+    var revokedAt: Instant? = null
+
+    val isActive: Boolean
+        get() {
+            if (revokedAt != null) return false
+            val exp = expiresAt ?: return true
+            return Instant.now().isBefore(exp)
+        }
+}

--- a/backend/data/src/main/kotlin/io/translately/data/entity/BaseEntity.kt
+++ b/backend/data/src/main/kotlin/io/translately/data/entity/BaseEntity.kt
@@ -1,0 +1,55 @@
+package io.translately.data.entity
+
+import io.translately.data.Ulid
+import jakarta.persistence.Column
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.MappedSuperclass
+import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
+import java.time.Instant
+
+/**
+ * Common base for every Translately entity.
+ *
+ * - `id` is an internal bigserial for FK relationships; **never expose to the API**.
+ * - `externalId` is a public-facing ULID, unique across the table, safe to return in
+ *   URLs and client responses.
+ * - `createdAt` / `updatedAt` are maintained by JPA lifecycle callbacks; no trigger
+ *   required. We never trust client-supplied timestamps.
+ * - Soft-delete (`deletedAt`) is opt-in per entity; not mixed into the base.
+ */
+@MappedSuperclass
+abstract class BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    var id: Long? = null
+        protected set
+
+    @Column(name = "external_id", nullable = false, updatable = false, length = 26, unique = true)
+    var externalId: String = Ulid.generate()
+        protected set
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant = Instant.now()
+        protected set
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: Instant = Instant.now()
+        protected set
+
+    @PrePersist
+    protected fun onPersist() {
+        val now = Instant.now()
+        if (createdAt == Instant.EPOCH) createdAt = now
+        updatedAt = now
+        if (externalId.isBlank()) externalId = Ulid.generate()
+    }
+
+    @PreUpdate
+    protected fun onUpdate() {
+        updatedAt = Instant.now()
+    }
+}

--- a/backend/data/src/main/kotlin/io/translately/data/entity/LanguageDirection.kt
+++ b/backend/data/src/main/kotlin/io/translately/data/entity/LanguageDirection.kt
@@ -1,0 +1,11 @@
+package io.translately.data.entity
+
+/**
+ * Text direction of a [ProjectLanguage]. Derived from the language tag at
+ * creation time (Arabic, Hebrew, Persian, Urdu → RTL; everything else → LTR)
+ * but stored explicitly so operators can override for uncommon dialects.
+ */
+enum class LanguageDirection {
+    LTR,
+    RTL,
+}

--- a/backend/data/src/main/kotlin/io/translately/data/entity/Organization.kt
+++ b/backend/data/src/main/kotlin/io/translately/data/entity/Organization.kt
@@ -1,0 +1,34 @@
+package io.translately.data.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.Instant
+
+/**
+ * Top-level tenant. Every business-domain row outside [User] carries an
+ * `organization_id` (enforced by [Project] and indirectly by the Hibernate
+ * multi-tenant filter in T111).
+ *
+ * `slug` is the URL-safe public identifier; shown to users in navigation
+ * breadcrumbs and some CLI commands.
+ */
+@Entity
+@Table(
+    name = "organizations",
+    uniqueConstraints = [UniqueConstraint(name = "uk_organizations_slug", columnNames = ["slug"])],
+)
+class Organization : BaseEntity() {
+    @Column(name = "slug", nullable = false, length = 64)
+    var slug: String = ""
+        set(value) {
+            field = value.trim().lowercase()
+        }
+
+    @Column(name = "name", nullable = false, length = 128)
+    var name: String = ""
+
+    @Column(name = "deleted_at")
+    var deletedAt: Instant? = null
+}

--- a/backend/data/src/main/kotlin/io/translately/data/entity/OrganizationMember.kt
+++ b/backend/data/src/main/kotlin/io/translately/data/entity/OrganizationMember.kt
@@ -1,0 +1,63 @@
+package io.translately.data.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.Instant
+
+/**
+ * Join table between [User] and [Organization] with a role.
+ *
+ * - One membership per (org, user) — enforced by unique constraint.
+ * - `invitedAt` records when the invitation was sent; `joinedAt` when accepted.
+ *   Pending invitations have `joinedAt = null`.
+ * - Removing a membership doesn't soft-delete either side; you just delete the
+ *   row and the access grant goes with it.
+ */
+@Entity
+@Table(
+    name = "organization_members",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_org_members_org_user", columnNames = ["organization_id", "user_id"]),
+    ],
+    indexes = [
+        Index(name = "idx_org_members_user", columnList = "user_id"),
+    ],
+)
+class OrganizationMember : BaseEntity() {
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+        name = "organization_id",
+        nullable = false,
+        foreignKey = ForeignKey(name = "fk_org_members_organization"),
+    )
+    lateinit var organization: Organization
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+        name = "user_id",
+        nullable = false,
+        foreignKey = ForeignKey(name = "fk_org_members_user"),
+    )
+    lateinit var user: User
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 16)
+    var role: OrganizationRole = OrganizationRole.MEMBER
+
+    @Column(name = "invited_at", nullable = false)
+    var invitedAt: Instant = Instant.now()
+
+    @Column(name = "joined_at")
+    var joinedAt: Instant? = null
+
+    val isPending: Boolean get() = joinedAt == null
+}

--- a/backend/data/src/main/kotlin/io/translately/data/entity/OrganizationRole.kt
+++ b/backend/data/src/main/kotlin/io/translately/data/entity/OrganizationRole.kt
@@ -1,0 +1,16 @@
+package io.translately.data.entity
+
+/**
+ * Role of a user within an organization. Orthogonal to project-level RBAC (which
+ * ships in T109). The highest role wins.
+ */
+enum class OrganizationRole {
+    /** Founding member or equivalent. Full billing + destructive rights. */
+    OWNER,
+
+    /** Can manage members, projects, and settings; no billing / delete-org. */
+    ADMIN,
+
+    /** Can read org metadata and join projects they are explicitly invited to. */
+    MEMBER,
+}

--- a/backend/data/src/main/kotlin/io/translately/data/entity/Pat.kt
+++ b/backend/data/src/main/kotlin/io/translately/data/entity/Pat.kt
@@ -1,0 +1,61 @@
+package io.translately.data.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.Instant
+
+/**
+ * Personal Access Token — user-scoped, cross-project, like a long-lived JWT
+ * that the user can revoke. Used by the CLI and by any integration that acts
+ * "as the user" without going through OAuth.
+ *
+ * Same storage model as [ApiKey]: show full token at creation once, keep only
+ * prefix + Argon2id hash. Authorization scope is carried with the token; the
+ * intersection of (user's org memberships) and (token scopes) wins.
+ */
+@Entity
+@Table(
+    name = "personal_access_tokens",
+    uniqueConstraints = [UniqueConstraint(name = "uk_pats_prefix", columnNames = ["prefix"])],
+    indexes = [Index(name = "idx_pats_user", columnList = "user_id")],
+)
+class Pat : BaseEntity() {
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = ForeignKey(name = "fk_pats_user"))
+    lateinit var user: User
+
+    @Column(name = "prefix", nullable = false, length = 16)
+    var prefix: String = ""
+
+    @Column(name = "secret_hash", nullable = false, length = 256)
+    var secretHash: String = ""
+
+    @Column(name = "name", nullable = false, length = 128)
+    var name: String = ""
+
+    @Column(name = "scopes", nullable = false, length = 512)
+    var scopes: String = ""
+
+    @Column(name = "expires_at")
+    var expiresAt: Instant? = null
+
+    @Column(name = "last_used_at")
+    var lastUsedAt: Instant? = null
+
+    @Column(name = "revoked_at")
+    var revokedAt: Instant? = null
+
+    val isActive: Boolean
+        get() {
+            if (revokedAt != null) return false
+            val exp = expiresAt ?: return true
+            return Instant.now().isBefore(exp)
+        }
+}

--- a/backend/data/src/main/kotlin/io/translately/data/entity/Project.kt
+++ b/backend/data/src/main/kotlin/io/translately/data/entity/Project.kt
@@ -1,0 +1,81 @@
+package io.translately.data.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.math.BigDecimal
+import java.time.Instant
+
+/**
+ * A localization project. The unit of authorization for translations, keys,
+ * screenshots, webhooks, glossaries, and the AI provider config.
+ *
+ * AI fields are all nullable — the platform must function with zero AI
+ * configured. When a provider is set, the API key is envelope-encrypted at
+ * rest via `security/CryptoService` (T112).
+ */
+@Entity
+@Table(
+    name = "projects",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_projects_org_slug", columnNames = ["organization_id", "slug"]),
+    ],
+    indexes = [
+        Index(name = "idx_projects_organization", columnList = "organization_id"),
+    ],
+)
+class Project : BaseEntity() {
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "organization_id", nullable = false, foreignKey = ForeignKey(name = "fk_projects_organization"))
+    lateinit var organization: Organization
+
+    @Column(name = "slug", nullable = false, length = 64)
+    var slug: String = ""
+        set(value) {
+            field = value.trim().lowercase()
+        }
+
+    @Column(name = "name", nullable = false, length = 128)
+    var name: String = ""
+
+    @Column(name = "description", length = 1024)
+    var description: String? = null
+
+    /** BCP 47 tag for the source language of the project (e.g. `en`, `en-US`, `de`). */
+    @Column(name = "base_language_tag", nullable = false, length = 32)
+    var baseLanguageTag: String = "en"
+
+    // ---- AI / BYOK (all nullable) ----
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ai_provider", length = 32)
+    var aiProvider: AiProvider? = null
+
+    @Column(name = "ai_model", length = 128)
+    var aiModel: String? = null
+
+    /** Optional override for OPENAI_COMPATIBLE endpoints (Ollama, vLLM, etc.). */
+    @Column(name = "ai_base_url", length = 512)
+    var aiBaseUrl: String? = null
+
+    /** Envelope-encrypted API key bytes. Raw key is never persisted. */
+    @Column(name = "ai_api_key_encrypted")
+    var aiApiKeyEncrypted: ByteArray? = null
+
+    /** Monthly USD cap; when usage meets or exceeds this, the provider auto-disables. */
+    @Column(name = "ai_budget_cap_usd_monthly", precision = 12, scale = 2)
+    var aiBudgetCapUsdMonthly: BigDecimal? = null
+
+    @Column(name = "deleted_at")
+    var deletedAt: Instant? = null
+
+    val hasAi: Boolean get() = aiProvider != null && aiApiKeyEncrypted != null
+}

--- a/backend/data/src/main/kotlin/io/translately/data/entity/ProjectLanguage.kt
+++ b/backend/data/src/main/kotlin/io/translately/data/entity/ProjectLanguage.kt
@@ -1,0 +1,46 @@
+package io.translately.data.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+/**
+ * A target language enabled for a [Project]. The project's base language tag
+ * (on [Project.baseLanguageTag]) is not stored as a ProjectLanguage row; it's
+ * implicit. Only *additional* target languages live here.
+ */
+@Entity
+@Table(
+    name = "project_languages",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_project_languages_project_tag", columnNames = ["project_id", "language_tag"]),
+    ],
+    indexes = [
+        Index(name = "idx_project_languages_project", columnList = "project_id"),
+    ],
+)
+class ProjectLanguage : BaseEntity() {
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "project_id", nullable = false, foreignKey = ForeignKey(name = "fk_project_languages_project"))
+    lateinit var project: Project
+
+    /** BCP 47 language tag, e.g. `de`, `fr-CA`, `pt-BR`. */
+    @Column(name = "language_tag", nullable = false, length = 32)
+    var languageTag: String = ""
+
+    /** Display name in the target language itself — e.g. "Deutsch", "Français". */
+    @Column(name = "name", nullable = false, length = 64)
+    var name: String = ""
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "direction", nullable = false, length = 8)
+    var direction: LanguageDirection = LanguageDirection.LTR
+}

--- a/backend/data/src/main/kotlin/io/translately/data/entity/User.kt
+++ b/backend/data/src/main/kotlin/io/translately/data/entity/User.kt
@@ -1,0 +1,53 @@
+package io.translately.data.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.Instant
+
+/**
+ * Authenticated human identity.
+ *
+ * - `email` is normalized to lowercase on write so unique-constraint lookups
+ *   are consistent regardless of what the user types.
+ * - `passwordHash` is `null` for users that only authenticate via OIDC / LDAP.
+ *   The local auth flow enforces a non-null hash separately in Phase 1 signup.
+ * - `emailVerifiedAt` doubles as the "can log in" flag — null means pending verify.
+ */
+@Entity
+@Table(
+    name = "users",
+    uniqueConstraints = [UniqueConstraint(name = "uk_users_email", columnNames = ["email"])],
+)
+class User : BaseEntity() {
+    @Column(name = "email", nullable = false, length = 254)
+    var email: String = ""
+        set(value) {
+            field = value.trim().lowercase()
+        }
+
+    @Column(name = "email_verified_at")
+    var emailVerifiedAt: Instant? = null
+
+    @Column(name = "password_hash", length = 256)
+    var passwordHash: String? = null
+
+    @Column(name = "full_name", nullable = false, length = 128)
+    var fullName: String = ""
+
+    @Column(name = "locale", nullable = false, length = 32)
+    var locale: String = "en"
+
+    @Column(name = "timezone", nullable = false, length = 64)
+    var timezone: String = "UTC"
+
+    @Column(name = "deleted_at")
+    var deletedAt: Instant? = null
+
+    /** True once the user has verified their email and is allowed to sign in. */
+    val isVerified: Boolean get() = emailVerifiedAt != null
+
+    /** True if local (email + password) authentication is configured. */
+    val hasLocalPassword: Boolean get() = !passwordHash.isNullOrBlank()
+}

--- a/backend/data/src/test/kotlin/io/translately/data/UlidTest.kt
+++ b/backend/data/src/test/kotlin/io/translately/data/UlidTest.kt
@@ -1,0 +1,92 @@
+package io.translately.data
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldMatch
+import java.time.Instant
+
+class UlidTest :
+    DescribeSpec({
+
+        describe("generate") {
+
+            it("produces 26-character output") {
+                Ulid.generate().length shouldBe 26
+            }
+
+            it("uses only Crockford base32 alphabet (no I, L, O, U)") {
+                val ulid = Ulid.generate()
+                ulid shouldMatch Regex("^[0-9A-HJKMNP-TV-Z]{26}$")
+            }
+
+            it("is unique across a large batch") {
+                val ulids = (1..10_000).map { Ulid.generate() }.toSet()
+                ulids shouldHaveSize 10_000
+            }
+
+            it("is monotonic when generated across time (timestamp prefix sorts correctly)") {
+                val first = Ulid.generate(Instant.ofEpochMilli(1_700_000_000_000L))
+                val later = Ulid.generate(Instant.ofEpochMilli(1_700_000_001_000L))
+                (later > first) shouldBe true
+            }
+
+            it("rejects timestamps outside the 48-bit range") {
+                shouldThrow<IllegalArgumentException> {
+                    Ulid.generate(Instant.ofEpochMilli(-1))
+                }
+                shouldThrow<IllegalArgumentException> {
+                    // 2^48 milliseconds > Instant.MAX; use a value beyond ULID range
+                    Ulid.generate(Instant.ofEpochMilli((1L shl 48)))
+                }
+            }
+
+            it("generates different ULIDs even when called with identical timestamps") {
+                val instant = Instant.ofEpochMilli(1_700_000_000_000L)
+                val a = Ulid.generate(instant)
+                val b = Ulid.generate(instant)
+                a shouldNotBe b
+                a.substring(0, 10) shouldBe b.substring(0, 10) // same time prefix
+            }
+        }
+
+        describe("extractTimestamp") {
+
+            it("round-trips a generated ULID back to its millisecond timestamp") {
+                val expected = Instant.ofEpochMilli(1_700_000_000_000L)
+                val ulid = Ulid.generate(expected)
+                Ulid.extractTimestamp(ulid) shouldBe expected
+            }
+
+            it("returns null for wrong-length input") {
+                Ulid.extractTimestamp("TOO_SHORT") shouldBe null
+                Ulid.extractTimestamp("X".repeat(27)) shouldBe null
+            }
+
+            it("returns null for out-of-alphabet characters") {
+                Ulid.extractTimestamp("!".repeat(26)) shouldBe null
+            }
+        }
+
+        describe("isValid") {
+
+            it("accepts a fresh ULID") {
+                Ulid.isValid(Ulid.generate()) shouldBe true
+            }
+
+            it("rejects wrong length") {
+                Ulid.isValid("01HT7F8XYZ") shouldBe false
+                Ulid.isValid("") shouldBe false
+            }
+
+            it("rejects characters outside the Crockford alphabet") {
+                Ulid.isValid("!".repeat(26)) shouldBe false
+            }
+
+            it("accepts lowercase input (case-insensitive)") {
+                Ulid.isValid(Ulid.generate().lowercase()) shouldBe true
+            }
+        }
+    })

--- a/backend/data/src/test/kotlin/io/translately/data/entity/OrganizationMemberTest.kt
+++ b/backend/data/src/test/kotlin/io/translately/data/entity/OrganizationMemberTest.kt
@@ -1,0 +1,26 @@
+package io.translately.data.entity
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.time.Instant
+
+class OrganizationMemberTest :
+    DescribeSpec({
+
+        describe("default role") {
+            it("is MEMBER") {
+                OrganizationMember().role shouldBe OrganizationRole.MEMBER
+            }
+        }
+
+        describe("pending state") {
+            it("is pending while joinedAt is null") {
+                OrganizationMember().isPending shouldBe true
+            }
+
+            it("stops being pending once joinedAt is set") {
+                val m = OrganizationMember().apply { joinedAt = Instant.now() }
+                m.isPending shouldBe false
+            }
+        }
+    })

--- a/backend/data/src/test/kotlin/io/translately/data/entity/OrganizationTest.kt
+++ b/backend/data/src/test/kotlin/io/translately/data/entity/OrganizationTest.kt
@@ -1,0 +1,26 @@
+package io.translately.data.entity
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class OrganizationTest :
+    DescribeSpec({
+
+        describe("slug normalization") {
+            it("lowercases on set") {
+                val org = Organization().apply { slug = "Acme-Corp" }
+                org.slug shouldBe "acme-corp"
+            }
+
+            it("trims whitespace") {
+                val org = Organization().apply { slug = "  acme-corp  " }
+                org.slug shouldBe "acme-corp"
+            }
+        }
+
+        describe("defaults") {
+            it("has a 26-char external ULID out of the box") {
+                Organization().externalId.length shouldBe 26
+            }
+        }
+    })

--- a/backend/data/src/test/kotlin/io/translately/data/entity/ProjectLanguageTest.kt
+++ b/backend/data/src/test/kotlin/io/translately/data/entity/ProjectLanguageTest.kt
@@ -1,0 +1,22 @@
+package io.translately.data.entity
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class ProjectLanguageTest :
+    DescribeSpec({
+
+        describe("direction default") {
+            it("is LTR out of the box") {
+                ProjectLanguage().direction shouldBe LanguageDirection.LTR
+            }
+        }
+
+        describe("field defaults") {
+            it("languageTag and name default to empty strings (must be set before persist)") {
+                val pl = ProjectLanguage()
+                pl.languageTag shouldBe ""
+                pl.name shouldBe ""
+            }
+        }
+    })

--- a/backend/data/src/test/kotlin/io/translately/data/entity/ProjectTest.kt
+++ b/backend/data/src/test/kotlin/io/translately/data/entity/ProjectTest.kt
@@ -1,0 +1,63 @@
+package io.translately.data.entity
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.math.BigDecimal
+
+class ProjectTest :
+    DescribeSpec({
+
+        describe("slug normalization") {
+            it("lowercases and trims") {
+                val p = Project().apply { slug = "  Mobile-App-Strings  " }
+                p.slug shouldBe "mobile-app-strings"
+            }
+        }
+
+        describe("hasAi flag") {
+            it("is false by default") {
+                Project().hasAi shouldBe false
+            }
+
+            it("is false when provider is set but key is null") {
+                val p = Project().apply { aiProvider = AiProvider.ANTHROPIC }
+                p.hasAi shouldBe false
+            }
+
+            it("is false when key is set but provider is null") {
+                val p = Project().apply { aiApiKeyEncrypted = byteArrayOf(1, 2, 3) }
+                p.hasAi shouldBe false
+            }
+
+            it("is true when both provider and key are set") {
+                val p =
+                    Project().apply {
+                        aiProvider = AiProvider.ANTHROPIC
+                        aiApiKeyEncrypted = byteArrayOf(1, 2, 3)
+                    }
+                p.hasAi shouldBe true
+            }
+        }
+
+        describe("defaults") {
+            it("baseLanguageTag defaults to 'en'") {
+                Project().baseLanguageTag shouldBe "en"
+            }
+
+            it("all AI fields default to null") {
+                val p = Project()
+                p.aiProvider shouldBe null
+                p.aiModel shouldBe null
+                p.aiBaseUrl shouldBe null
+                p.aiApiKeyEncrypted shouldBe null
+                p.aiBudgetCapUsdMonthly shouldBe null
+            }
+        }
+
+        describe("budget cap accepts 2-decimal BigDecimal") {
+            it("stores and retrieves the value exactly") {
+                val p = Project().apply { aiBudgetCapUsdMonthly = BigDecimal("49.99") }
+                p.aiBudgetCapUsdMonthly shouldBe BigDecimal("49.99")
+            }
+        }
+    })

--- a/backend/data/src/test/kotlin/io/translately/data/entity/TokenActiveTest.kt
+++ b/backend/data/src/test/kotlin/io/translately/data/entity/TokenActiveTest.kt
@@ -1,0 +1,59 @@
+package io.translately.data.entity
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.time.Instant
+
+/**
+ * The active-flag logic is identical for [ApiKey] and [Pat], so this suite
+ * exercises both via a parameterized pattern to ensure drift can't happen.
+ */
+class TokenActiveTest :
+    DescribeSpec({
+
+        describe("ApiKey.isActive") {
+            it("is active by default (no expiry, not revoked)") {
+                ApiKey().isActive shouldBe true
+            }
+
+            it("is inactive once revoked") {
+                val k = ApiKey().apply { revokedAt = Instant.now() }
+                k.isActive shouldBe false
+            }
+
+            it("is inactive after expiry") {
+                val k = ApiKey().apply { expiresAt = Instant.now().minusSeconds(1) }
+                k.isActive shouldBe false
+            }
+
+            it("is active when expiry is in the future") {
+                val k = ApiKey().apply { expiresAt = Instant.now().plusSeconds(3600) }
+                k.isActive shouldBe true
+            }
+
+            it("revocation beats expiry") {
+                val k =
+                    ApiKey().apply {
+                        expiresAt = Instant.now().plusSeconds(3600)
+                        revokedAt = Instant.now()
+                    }
+                k.isActive shouldBe false
+            }
+        }
+
+        describe("Pat.isActive") {
+            it("mirrors the ApiKey logic (default active)") {
+                Pat().isActive shouldBe true
+            }
+
+            it("is inactive once revoked") {
+                val t = Pat().apply { revokedAt = Instant.now() }
+                t.isActive shouldBe false
+            }
+
+            it("is inactive after expiry") {
+                val t = Pat().apply { expiresAt = Instant.now().minusSeconds(1) }
+                t.isActive shouldBe false
+            }
+        }
+    })

--- a/backend/data/src/test/kotlin/io/translately/data/entity/UserTest.kt
+++ b/backend/data/src/test/kotlin/io/translately/data/entity/UserTest.kt
@@ -1,0 +1,66 @@
+package io.translately.data.entity
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.time.Instant
+
+class UserTest :
+    DescribeSpec({
+
+        describe("email normalization") {
+            it("lowercases the email on set") {
+                val u = User().apply { email = "Pratiyush@Example.COM" }
+                u.email shouldBe "pratiyush@example.com"
+            }
+
+            it("trims leading/trailing whitespace") {
+                val u = User().apply { email = "  user@example.com  " }
+                u.email shouldBe "user@example.com"
+            }
+        }
+
+        describe("verification status") {
+            it("is not verified when emailVerifiedAt is null") {
+                User().isVerified shouldBe false
+            }
+
+            it("is verified once emailVerifiedAt is set") {
+                val u = User().apply { emailVerifiedAt = Instant.now() }
+                u.isVerified shouldBe true
+            }
+        }
+
+        describe("local password") {
+            it("hasLocalPassword=false when passwordHash is null") {
+                User().hasLocalPassword shouldBe false
+            }
+
+            it("hasLocalPassword=false when passwordHash is blank") {
+                User().apply { passwordHash = "   " }.hasLocalPassword shouldBe false
+            }
+
+            it("hasLocalPassword=true when passwordHash is present") {
+                val hash = "\$argon2id\$v=19\$m=65536,t=3,p=4\$abc\$def"
+                val user = User().apply { passwordHash = hash }
+                user.hasLocalPassword shouldBe true
+            }
+        }
+
+        describe("default values") {
+            it("defaults locale to 'en' and timezone to 'UTC'") {
+                val u = User()
+                u.locale shouldBe "en"
+                u.timezone shouldBe "UTC"
+            }
+
+            it("generates a non-blank external ULID on construction") {
+                User().externalId shouldNotBe ""
+                User().externalId.length shouldBe 26
+            }
+
+            it("assigns different external IDs to each new instance") {
+                User().externalId shouldNotBe User().externalId
+            }
+        }
+    })

--- a/buildSrc/src/main/kotlin/translately.quarkus-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/translately.quarkus-module.gradle.kts
@@ -32,14 +32,18 @@ dependencies {
     "testImplementation"(versionCatalog.findLibrary("mockk").get())
 }
 
-// CDI beans written as Kotlin classes need the `all-open` plugin to be non-final.
+// CDI beans + JPA entities written as Kotlin classes need the `all-open` plugin
+// to be non-final so the container can create proxies.
 allOpen {
     annotation("jakarta.enterprise.context.ApplicationScoped")
     annotation("jakarta.enterprise.context.RequestScoped")
     annotation("jakarta.inject.Singleton")
+    annotation("jakarta.persistence.Entity")
+    annotation("jakarta.persistence.MappedSuperclass")
+    annotation("jakarta.persistence.Embeddable")
 }
 
-// @Entity data classes need a no-arg constructor for Hibernate.
+// @Entity classes need a no-arg constructor for Hibernate.
 noArg {
     annotation("jakarta.persistence.Entity")
     annotation("jakarta.persistence.Embeddable")


### PR DESCRIPTION
## Summary

Closes #19. First code PR of Phase 1. Seven entities + three enums + ULID + 47 Kotest assertions.

## Why

Every Phase 1 ticket after this (migration, signup, JWT, RBAC, multi-tenant filter, OpenAPI) builds on a shared entity model. Landing entities alone in a small PR keeps the Flyway migration (T102) and the runtime wiring (T103–T113) reviewable separately.

## How

```
backend/data/src/main/kotlin/io/translately/data/
├── Ulid.kt                                  # Crockford-base32 generator
├── entity/
│   ├── BaseEntity.kt                        # bigserial id + ULID + timestamps
│   ├── AiProvider.kt                        # enum: ANTHROPIC / OPENAI / OPENAI_COMPATIBLE
│   ├── LanguageDirection.kt                 # enum: LTR / RTL
│   ├── OrganizationRole.kt                  # enum: OWNER / ADMIN / MEMBER
│   ├── User.kt                              # + isVerified / hasLocalPassword
│   ├── Organization.kt
│   ├── OrganizationMember.kt                # join, unique (org, user)
│   ├── Project.kt                           # + BYOK AI fields, hasAi flag
│   ├── ProjectLanguage.kt
│   ├── ApiKey.kt                            # + isActive
│   └── Pat.kt                               # + isActive
└── (tests mirror this structure)
```

Plus: buildSrc convention plugin adds `@Entity` / `@MappedSuperclass` / `@Embeddable` to `allOpen` so Kotlin entity classes are non-final for Hibernate.

## Tests

- [x] 47 Kotest tests across 7 suites — see CHANGELOG entry for breakdown. All green, 0 skips.
- [x] `./gradlew :backend:data:ktlintCheck :backend:data:detekt` — green.
- [x] `./gradlew :backend:app:compileKotlin` — Quarkus app still compiles with new entities on its classpath.

## Pre-merge checklist

- [x] PR is one intent (entities + supporting ULID + buildSrc allOpen tweak)
- [ ] All CI checks green
- [x] Linked issue closed by `Closes #19`
- [x] No migration in this PR — T102 lands the corresponding `V1__auth_and_orgs.sql`
- [x] `CHANGELOG.md` Unreleased updated
- [x] No breaking change
- [x] No new dependency
- [x] No dead TODO/FIXME
- [x] N/A — no UI change
- [x] N/A — no UI change
- [x] Security: no secrets; `ApiKey.secretHash` + `Pat.secretHash` store Argon2id hashes only (implementation in T110)
- [x] No N+1 concerns — no queries yet; FKs declared `FetchType.LAZY`
- [x] Commit GPG-signed, Pratiyush only
- [x] Self-reviewed every changed line

Closes #19