### PR TITLE
docs(docs): add rule \u2014 keep GitHub Pages in sync with product changes

### DIFF
--- a/.kiro/steering/contributing-rules.md
+++ b/.kiro/steering/contributing-rules.md
@@ -87,4 +87,13 @@ Docs-only PRs still require link-checker green.
 
 - Every changed line read. No rubber-stamping.
 - At least one concrete improvement suggested OR an explicit "LGTM: nothing to add".
-- Block on: missing tests, missing migration, missing changelog entry, unsigned commits, co-author trailers, license violations, security smells.
+- Block on: missing tests, missing migration, missing changelog entry, unsigned commits, co-author trailers, license violations, security smells, **`docs/` page out of sync with the product**.
+
+## Keep GitHub Pages live
+
+The canonical docs live at <https://pratiyush.github.io/translately/>, served from the repo's `docs/` directory by the `pages.yml` workflow (deploys on every push to `master`).
+
+- **Same-PR rule.** When a user-visible feature, flow, config knob, or API surface changes, update the matching page under `docs/` in the **same** PR. The 14-point PR checklist treats out-of-date docs as a blocker.
+- **Tag-gate rule.** Before pushing a signed `v0.X.Y` tag, skim the live Pages site and confirm it reflects the release contents; note any stale page in the release retrospective.
+- **Phase end.** Each phase retrospective explicitly checks that the roadmap, quickstart, and any newly-shipped pages are reachable and current on the live site.
+- **Empty pages rule.** A page that promises content we haven't shipped yet must carry a "placeholder — full content ships in vX.Y.Z" banner, not silently 404 or mislead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ Read these four files before any non-trivial change:
 - No N+1 queries; check Hibernate stats before declaring a DB-touching PR done.
 - Every UI change verified in light AND dark mode; keyboard nav; axe 0 violations.
 - Every new endpoint documented via OpenAPI annotations; regenerate SDK + webapp API client.
+- Keep the GitHub Pages site (`docs/`) in lock-step with product reality. Update the matching page in the same PR that ships the behaviour; verify the Pages deploy at <https://pratiyush.github.io/translately/> refreshes after every signed tag. Stale docs are worse than missing docs.
 
 ## Conventional Commits
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ Kiro steering files under [.kiro/steering/](.kiro/steering/) are authoritative f
 6. **Phase → minor version.** Phase N → v0.N.0; v1.0.0 at Phase 7. GPG-signed tags trigger `release.yml`.
 7. **Light + dark + keyboard + a11y** verified for every UI change. WCAG 2.1 AA minimum.
 8. **No new dependency without justification** (license check, maintenance health, size).
+9. **Keep the GitHub Pages site (`docs/`) updated alongside product changes.** When a feature ships or a user-visible flow changes, update the matching page under `docs/` in the same PR. When a signed tag goes out, verify the Pages deploy at <https://pratiyush.github.io/translately/> reflects the new content (the `pages.yml` workflow deploys on every push to `master`). Stale docs are worse than missing docs — they mislead users and dampen trust.
 
 ## Stack cheat-sheet
 


### PR DESCRIPTION
## Summary

Adds a hard rule and a dedicated steering section requiring that the GitHub Pages site (`docs/`) is updated in the same PR as any user-visible change, and verified live after each signed tag.

## Why

Pages is the first thing a new user sees. Stale pages mislead readers and dampen trust. Codifying this as a rule means reviewers block on it and agents update `docs/` automatically when they change behaviour.

## How

- **CLAUDE.md** — hard rule #9.
- **AGENTS.md** — matching rule in the vendor-neutral agent contract.
- **.kiro/steering/contributing-rules.md** — new `Keep GitHub Pages live` section covering:
  - same-PR rule
  - tag-gate rule (skim live site before signing a tag)
  - phase-end retrospective check
  - empty-pages rule (placeholder with target version, never a 404)
- Reviewer blocker list gains `docs/ page out of sync with product`.

## Tests

- [x] Diff reviewed; three rule files updated cohesively.
- [x] No code change; docs-only.

## Pre-merge checklist

- [x] PR is one intent (add a rule)
- [ ] All CI checks green (docs-only — link-checker + CodeQL actions)
- [x] No issue link needed (meta rule update)
- [x] No migrations
- [x] No CHANGELOG entry needed (internal rule)
- [x] No breaking change
- [x] No dependency change
- [x] No dead TODO/FIXME
- [x] N/A — no UI
- [x] N/A — no UI
- [x] No secrets
- [x] No queries
- [x] Commit GPG-signed, Pratiyush only
- [x] Self-reviewed every changed line