### PR TITLE
chore(infra): ignore .claude/worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ secrets/
 
 # Per-user Claude harness settings (keep `.claude/commands/`, skip local settings)
 .claude/settings.local.json
+# Transient git worktrees used by the local agent harness (never committed)
+.claude/worktrees/
 
 # TypeScript incremental build info
 *.tsbuildinfo


### PR DESCRIPTION
## Summary

Adds `.claude/worktrees/` to `.gitignore` so the transient git worktrees that the local agent harness creates don't appear as untracked files in `git status`.

The local agent harness checks out feature branches into `.claude/worktrees/agent-<id>/` so multiple agents can work in isolation on the same repo. These are ephemeral — created at agent start, removed when the agent reports back — and must never be committed. Ignoring the parent keeps `git status` clean on every machine that runs agents this way.

## 14-point pre-merge checklist

- [x] **One intent** — pure `.gitignore` addition, no behavior change.
- [x] **Conventional Commits title** — `chore(infra): ignore .claude/worktrees/ directory`.
- [x] **GPG-signed commit** — RSA key `46AF5131F4540993C2C17E129BDF8BAF8DBBDF08`.
- [x] **Author Pratiyush only** — no AI co-author trailers.
- [x] **Golden rule** — no forbidden-name mention.
- [x] **Tests** — no runtime code changed; N/A.
- [x] **Lint / typecheck / build** — none affected.
- [x] **Docs / CHANGELOG** — infra-only chore, not user-facing; no CHANGELOG entry needed.

## Why a separate tiny PR

PR #125 (T115 app shell) was in flight when the worktree harness first surfaced these stale entries, and bundling this into the webapp PR would have violated "one intent per PR". Separating keeps the history auditable.