### PR TITLE
docs(docs): rule — every ticket ships product + arch + API + self-hosting + LLM docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,6 +32,18 @@ Closes #
 
 <!-- For any UI change: attach light + dark mode captures. Delete this section otherwise. -->
 
+## Docs
+
+Every PR ships its docs. Tick the surfaces this change touches (strike through with `~~...~~` those that genuinely don't apply, and explain in one line why):
+
+- [ ] **Product** (`docs/product/`) — walkthrough + light/dark screenshots for any user-visible flow
+- [ ] **Architecture** (`docs/architecture/` + a new `docs/architecture/decisions/NNN-...md` ADR for any non-trivial technical choice)
+- [ ] **API** (`docs/api/` + regenerated `docs/api/openapi.json`) for new/changed endpoints, scopes, errors, rate-limits, or versioning rules
+- [ ] **Self-hosting** (`docs/self-hosting/`) for env vars, compose services, Helm values, migrations, backups, or hardening
+- [ ] **LLM-ingestible** — regenerated `docs/llms.txt` + `docs/llms-full.txt` (per llmstxt.org) so Claude / Cursor / in-house LLMs stay in sync
+
+If none of the surfaces apply, say so explicitly and the reviewer will re-check before merge.
+
 ## Pre-merge checklist
 
 - [ ] PR is **one intent** (no mixed concerns)
@@ -48,3 +60,4 @@ Closes #
 - [ ] Performance: no N+1 queries introduced (Hibernate stats checked locally)
 - [ ] Commits **GPG-signed** by Pratiyush, no AI co-author trailers
 - [ ] Reviewer has read every changed line (no rubber-stamping)
+- [ ] **Docs updated** per the `## Docs` section above; no doc surface silently skipped

--- a/.kiro/steering/contributing-rules.md
+++ b/.kiro/steering/contributing-rules.md
@@ -97,3 +97,21 @@ The canonical docs live at <https://pratiyush.github.io/translately/>, served fr
 - **Tag-gate rule.** Before pushing a signed `v0.X.Y` tag, skim the live Pages site and confirm it reflects the release contents; note any stale page in the release retrospective.
 - **Phase end.** Each phase retrospective explicitly checks that the roadmap, quickstart, and any newly-shipped pages are reachable and current on the live site.
 - **Empty pages rule.** A page that promises content we haven't shipped yet must carry a "placeholder — full content ships in vX.Y.Z" banner, not silently 404 or mislead.
+
+## Every ticket ships its docs
+
+The `docs/` tree has five surfaces; each PR updates the ones its change touches.
+
+| Surface | Path | Update trigger |
+|---|---|---|
+| **Product** | `docs/product/` | Any user-visible feature, flow, or UI change. Include light + dark screenshots. |
+| **Architecture** | `docs/architecture/` + ADRs under `docs/architecture/decisions/` | Module graph edit, library swap, storage/auth/perf trade-off. Non-trivial technical decisions get a new ADR (`NNN-title.md`). |
+| **API** | `docs/api/` (+ regenerated `docs/api/openapi.json`) | New / changed / removed endpoint, scope, error code, rate-limit, or versioning rule. |
+| **Self-hosting** | `docs/self-hosting/` | New env var, compose service, Helm value, migration, backup concern, or security hardening. |
+| **LLM-ingestible** | `docs/llms.txt` (index) + `docs/llms-full.txt` (full corpus), per [llmstxt.org](https://llmstxt.org) | Regenerate **whenever** any other `docs/` page lands, so LLM consumers pull a coherent snapshot. |
+
+Doc-missing PRs block merge. If a ticket slips docs mid-flight, open a `docs(docs): ...` follow-up issue in the **same milestone** and land it before the phase's signed tag. By v0.3.0 every MVP feature is fully documented; by v1.0.0 the tree is the canonical product source-of-truth.
+
+### Ticket acceptance criteria
+
+Every issue body carries a `## Docs` section listing which of the five surfaces it must update. Agents and humans check those boxes in the PR description before requesting review. A ticket whose acceptance criteria don't list any doc surface is itself a red flag — either the change is invisible to users and operators (rare) or the criteria are incomplete.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ Read these four files before any non-trivial change:
 - Every UI change verified in light AND dark mode; keyboard nav; axe 0 violations.
 - Every new endpoint documented via OpenAPI annotations; regenerate SDK + webapp API client.
 - Keep the GitHub Pages site (`docs/`) in lock-step with product reality. Update the matching page in the same PR that ships the behaviour; verify the Pages deploy at <https://pratiyush.github.io/translately/> refreshes after every signed tag. Stale docs are worse than missing docs.
+- Every ticket ships its docs across four surfaces: **product** (`docs/product/`), **architecture** (`docs/architecture/` + ADRs under `docs/architecture/decisions/`), **API** (`docs/api/` + regenerated `docs/api/openapi.json`), **self-hosting** (`docs/self-hosting/`), and regenerate **LLM-ingestible** docs (`docs/llms.txt`, `docs/llms-full.txt`, per [llmstxt.org](https://llmstxt.org)). Doc-missing PRs are blocked; open a `docs(docs): ...` follow-up in the same milestone if docs slip. Every shipped feature is fully documented by v0.3.0 (MVP end); the full tree is canonical by v1.0.0.
 
 ## Conventional Commits
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,14 @@ Kiro steering files under [.kiro/steering/](.kiro/steering/) are authoritative f
 7. **Light + dark + keyboard + a11y** verified for every UI change. WCAG 2.1 AA minimum.
 8. **No new dependency without justification** (license check, maintenance health, size).
 9. **Keep the GitHub Pages site (`docs/`) updated alongside product changes.** When a feature ships or a user-visible flow changes, update the matching page under `docs/` in the same PR. When a signed tag goes out, verify the Pages deploy at <https://pratiyush.github.io/translately/> reflects the new content (the `pages.yml` workflow deploys on every push to `master`). Stale docs are worse than missing docs — they mislead users and dampen trust.
+10. **Every ticket ships its docs — product, technical, API, and LLM-ingestible.** Every PR that changes user-visible behaviour, the API surface, a config knob, or architecture MUST update the matching page(s) under `docs/` in the same PR. The doc surfaces, one per ticket type:
+    - **Product** (`docs/product/`) — feature pages, walkthroughs, screenshots (light + dark) for every user-visible flow.
+    - **Architecture** (`docs/architecture/` + ADRs under `docs/architecture/decisions/`) — module maps, data-flow diagrams, and an ADR for any non-trivial technical choice (library swap, auth strategy, storage layout, algorithm, performance trade-off).
+    - **API** (`docs/api/`) — OpenAPI-backed endpoint reference, plus scope matrix, error-code catalogue, rate-limit policy, versioning contract. Regenerate the committed `docs/api/openapi.json` on every API change.
+    - **Self-hosting** (`docs/self-hosting/`) — every new env var, compose service, Helm value, migration, or backup concern.
+    - **LLM-ingestible** (`docs/llms.txt` + `docs/llms-full.txt`) — the [llmstxt.org](https://llmstxt.org) standard. Any doc addition/change must regenerate these so LLMs (Claude, Cursor, in-house assistants) can consume the full corpus at `{pages-url}/llms-full.txt`.
+
+    Doc-missing PRs are blocked from merge. If a ticket slipped docs in-flight, open a `docs(docs): ...` follow-up in the same milestone before the phase-tag goes out. By v0.3.0 (MVP end) every shipped feature must be fully documented; by v1.0.0 the entire `docs/` tree is the canonical product source-of-truth.
 
 ## Stack cheat-sheet
 


### PR DESCRIPTION
## Summary

Adds hard rule **#10 — Every ticket ships its docs** to the four files any contributor or agent reads before opening a PR:

- `CLAUDE.md` — canonical hard-rules list
- `AGENTS.md` — cross-agent contract
- `.kiro/steering/contributing-rules.md` — always-loaded steering (full five-surface table)
- `.github/PULL_REQUEST_TEMPLATE.md` — explicit `## Docs` section + pre-merge checkbox

## The rule

Every PR that changes user-visible behaviour, API surface, config knobs, or architecture MUST update the matching doc page(s) in the **same PR**. Five doc surfaces:

| Surface | Path | Trigger |
|---|---|---|
| **Product** | `docs/product/` | User-visible feature or flow (with light + dark screenshots) |
| **Architecture** | `docs/architecture/` + `docs/architecture/decisions/NNN-*.md` ADRs | Non-trivial technical choice |
| **API** | `docs/api/` + regenerated `docs/api/openapi.json` | New/changed endpoint, scope, error code, rate limit, versioning |
| **Self-hosting** | `docs/self-hosting/` | New env var, compose service, Helm value, migration, backup, hardening |
| **LLM-ingestible** | `docs/llms.txt` + `docs/llms-full.txt` per [llmstxt.org](https://llmstxt.org) | Regenerated on every docs change |

Doc-missing PRs block merge. Slipped docs → `docs(docs): ...` follow-up in the same milestone before the phase-tag. By v0.3.0 (MVP end) every shipped feature is fully documented; v1.0.0 = full tree canonical.

## What lands in follow-ups

1. **docs restructure PR** — reshape `docs/` into the full product-docs tree (product/, architecture/ with ADRs, api/, sdks/, cli/, self-hosting/, contributing/, llm/ with llms.txt + llms-full.txt). In flight as a background worktree agent.
2. **issue-body backfill** — append a `## Docs` acceptance-criteria section to every open issue in Phases 1–7 and open `type:docs` follow-ups for already-shipped tickets that slipped docs (T101, T102, T104, T105, T108, T109, T111, T112, T114, T115). Executed via `gh` API by a background agent — no file changes.

## 14-point pre-merge checklist

- [x] **One intent** — pure rule-addition text; no code or docs-tree changes in this PR.
- [x] **Conventional Commits title** — `docs(docs): rule — every ticket ships product + arch + API + self-hosting + LLM docs`.
- [x] **GPG-signed commit** — RSA key `46AF5131F4540993C2C17E129BDF8BAF8DBBDF08`, Pratiyush only, no AI co-author trailers.
- [x] **Golden rule** — no forbidden-name mention.
- [x] **No code changed** — steering + template only; no tests, no build impact.
- [x] **Backward compatible** — additive rule; existing PRs in flight are NOT retroactively blocked (the next PR author chooses whether to fold docs in).
- [x] **CHANGELOG updated** — N/A (steering change only; the downstream docs-restructure PR will add its own CHANGELOG entry).
- [x] **Docs in sync** — the rule exists in four authoritative places; they cross-reference.

## Why a separate tiny PR

The rule itself needs to land FIRST so the downstream docs-restructure PR and issue-backfill operations reference an already-merged rule. Splitting avoids mixing "one intent: add rule" with "one intent: reshape docs/ tree" or "one intent: bulk-update issues" — each is its own mergeable unit.