### PR TITLE
docs(docs): drop orphaned llms-full.txt from Jekyll exclude (fix 404)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -93,7 +93,6 @@ exclude:
   - vendor/
   - node_modules/
   - README.md # repo-facing; docs/index.md is the site root
-  - llms-full.txt
 
 # Default layout for any page without an explicit one.
 defaults:


### PR DESCRIPTION
## Summary

Removes the stray `- llms-full.txt` line that stayed in `docs/_config.yml` after [PR #145](https://github.com/Pratiyush/translately/pull/145), so the LLM corpus link on the landing page and footer resolves instead of 404ing.

## Why

After PR #145 I verified the live site. Three URLs we care about:

| URL | Status |
|---|---|
| `/translately/downloads/translately-docs.zip` | **200 OK** ✓ |
| `/translately/llms.txt` | **200 OK** ✓ |
| `/translately/llms-full.txt` | **404** ✗ |

The Pages deploy log surfaced the culprit:

```
EntryFilter: excluded /llms-full.txt
```

Root cause: my PR #145 Edit replaced the old `exclude:` + `include:` blocks but matched a prefix that left `- llms-full.txt` orphaned as the last item of `exclude:`. One-line drop.

## How

Delete the single stray line from `docs/_config.yml`.

## Tests

- [x] `git diff` shows only the intended 1-line removal.
- [ ] Live verification lands on the next Pages deploy (~1 minute).

## Screenshots

n/a — config only.

## Docs

- ~~All surfaces~~ — no content change; fix makes an already-committed file *reachable* on the live site.

## Pre-merge checklist

- [x] PR is **one intent** — fix the 404.
- [ ] CI green — pending.
- [x] Linked issue — none (follow-up to #145).
- [x] Migrations — n/a.
- [x] CHANGELOG — not required for a same-release tweak.
- [x] Breaking changes — none.
- [x] No new dependency — none.
- [x] No outdated code left behind — one-line delete.
- [x] **Light AND dark** — n/a.
- [x] **A11y** — n/a.
- [x] Security — none.
- [x] Performance — n/a.
- [x] Commits **GPG-signed** by Pratiyush — verified.
- [ ] Reviewer — pending.
- [x] **Docs updated** — config comment from #145 already explains the gotcha; this PR just applies it.