### PR TITLE
chore(infra): set repo topics + add rule #11 for topic/label curation

### DIFF
--- a/.kiro/steering/contributing-rules.md
+++ b/.kiro/steering/contributing-rules.md
@@ -44,6 +44,56 @@ NEW → TRIAGED → READY → IN-PROGRESS → IN-REVIEW → MERGED → RELEASED 
 
 Every issue must carry **type** + **scope** + **phase-milestone** + **estimate** labels before leaving NEW. Estimate labels: `xs` ≤1h, `s` ≤4h, `m` ≤1d, `l` ≤3d, `xl` ≥1w (must be split before READY).
 
+## Repository metadata
+
+Keeping the repo's discoverability surfaces curated is a CLAUDE.md rule (#11). Two things to maintain in lockstep with the stack.
+
+### Repo topics
+
+The GitHub Topics list is the first thing a browser sees on the repo page. The canonical set (15 topics, pinned here):
+
+```
+localization  translation-management  i18n  translation  self-hosted
+open-source   mit-license             quarkus  kotlin     java
+react         typescript              tailwindcss  icu-messageformat  byok
+```
+
+Set / update via the GitHub API:
+
+```bash
+gh api -X PUT repos/Pratiyush/translately/topics \
+  -f 'names[]=localization' -f 'names[]=translation-management' \
+  -f 'names[]=i18n' -f 'names[]=translation' \
+  -f 'names[]=self-hosted' -f 'names[]=open-source' \
+  -f 'names[]=mit-license' -f 'names[]=quarkus' \
+  -f 'names[]=kotlin' -f 'names[]=java' \
+  -f 'names[]=react' -f 'names[]=typescript' \
+  -f 'names[]=tailwindcss' -f 'names[]=icu-messageformat' \
+  -f 'names[]=byok'
+```
+
+**When to edit the list:**
+
+- A new headline capability ships (e.g. add `openapi` alongside T113 going out, `jwt` if we ever front the auth story as a headline).
+- A major stack swap (unlikely, but documented here so the review happens).
+- Every signed tag — the release PR checks the topics list against this file.
+
+GitHub caps at 20 topics; keep headroom. Prefer widely-used GitHub topic slugs (check via <https://github.com/topics>) over bespoke names so search finds us.
+
+### Issue labels
+
+The label taxonomy lives on GitHub (`gh label list`) and breaks into five axes — **every** open issue carries one label from each:
+
+| Axis | Labels | Notes |
+|---|---|---|
+| **Type** | `type:feat`, `type:fix`, `type:chore`, `type:docs`, `type:test`, `type:refactor`, `type:perf`, `type:security`, `type:breaking` | Matches the Conventional Commits type set exactly. |
+| **Scope** | `scope:backend`, `scope:webapp`, `scope:sdk-js`, `scope:cli`, `scope:infra`, `scope:docs` | Matches the Conventional Commits scope set exactly. |
+| **Estimate** | `est:xs` ≤1h, `est:s` ≤4h, `est:m` ≤1d, `est:l` ≤3d, `est:xl` ≥1w | `xl` issues must be split before leaving READY. |
+| **Phase milestone** | `Phase 0 — Bootstrap → v0.0.1` through `Phase 7 — … → v1.0.0`; `Deferred — post-v1.0.0 or not planned` | Milestone, not label — enforced by the issue-template defaults. |
+| **Release lens** | `mvp` · `post-mvp` · `deferred` · `target` · `blocked` | `mvp` = Phases 0–3 (the first runnable product). `target` = in the active work queue toward the next signed tag. `blocked` = external dependency. |
+
+Issue templates under `.github/ISSUE_TEMPLATE/` preset the first four; reviewers add `target` / `blocked` during triage.
+
 ## Tests
 
 - **Tests first** for new behaviour where the shape is clear (TDD).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ Kiro steering files under [.kiro/steering/](.kiro/steering/) are authoritative f
     - **LLM-ingestible** (`docs/llms.txt` + `docs/llms-full.txt`) — the [llmstxt.org](https://llmstxt.org) standard. Any doc addition/change must regenerate these so LLMs (Claude, Cursor, in-house assistants) can consume the full corpus at `{pages-url}/llms-full.txt`.
 
     Doc-missing PRs are blocked from merge. If a ticket slipped docs in-flight, open a `docs(docs): ...` follow-up in the same milestone before the phase-tag goes out. By v0.3.0 (MVP end) every shipped feature must be fully documented; by v1.0.0 the entire `docs/` tree is the canonical product source-of-truth.
+11. **Repo topics + per-issue labels kept curated.** The GitHub repo's Topics list (set via `gh api repos/.../topics`) drives discoverability — the canonical list lives in [`.kiro/steering/contributing-rules.md#repository-metadata`](.kiro/steering/contributing-rules.md#repository-metadata). Review it at every signed tag and add a topic when a new headline feature ships (e.g. `react` when the webapp goes live, `openapi` when the spec is published). **Every issue** carries `type:*`, `scope:*`, `est:*`, phase-milestone, and `mvp`/`post-mvp`/`deferred` labels before leaving NEW. A PR that creates a new issue without the full label set is blocked at review.
 
 ## Stack cheat-sheet
 


### PR DESCRIPTION
## Summary

Landed two governance pieces:

1. **Set 15 repo topics** on the GitHub repo (`gh api repos/Pratiyush/translately/topics`) so github.com search + topic browsing finds us. The list is: `localization`, `translation-management`, `i18n`, `translation`, `self-hosted`, `open-source`, `mit-license`, `quarkus`, `kotlin`, `java`, `react`, `typescript`, `tailwindcss`, `icu-messageformat`, `byok`.
2. **CLAUDE.md rule #11** + matching section in `.kiro/steering/contributing-rules.md` so the list + the per-issue label scheme stay curated, with a review checkpoint at every signed tag.

## Why

Two gaps surfaced while preparing Phase 1:

- Repo Topics list was empty (`gh api repos/Pratiyush/translately --jq .topics` returned `[]`). We're shipping an open-source localization platform targeting a specific community and github.com's discovery surfaces couldn't find us.
- Contributors had no single place listing the five issue-label axes (Type / Scope / Estimate / Phase milestone / Release lens) or the canonical topic list. Release PRs need something to diff against.

## How

### Rule #11 in CLAUDE.md

```
11. **Repo topics + per-issue labels kept curated.** The GitHub repo's
    Topics list (set via `gh api repos/.../topics`) drives
    discoverability — the canonical list lives in
    `.kiro/steering/contributing-rules.md#repository-metadata`. Review
    it at every signed tag and add a topic when a new headline feature
    ships (e.g. `react` when the webapp goes live, `openapi` when the
    spec is published). **Every issue** carries `type:*`, `scope:*`,
    `est:*`, phase-milestone, and `mvp`/`post-mvp`/`deferred` labels
    before leaving NEW. A PR that creates a new issue without the full
    label set is blocked at review.
```

### New section in `.kiro/steering/contributing-rules.md`

- The canonical 15-topic block pinned inline.
- The `gh` command to update it (copy-paste).
- A table of the five issue-label axes with the exact label strings.
- Where each comes from (Conventional Commits types map exactly; `target`, `blocked` added during triage).

## Tests

n/a — content-only governance change; lychee will validate the cross-links between CLAUDE.md and the steering file.

## Screenshots

n/a — topic change is visible on <https://github.com/Pratiyush/translately>; no repo docs UI surface.

## Docs

- ~~**Product**~~ — governance, no user-visible change.
- ~~**Architecture**~~ — none.
- ~~**API**~~ — none.
- ~~**Self-hosting**~~ — none.
- ~~**LLM-ingestible**~~ — CLAUDE.md + `.kiro/` live outside `docs/`, so `docs/llms-full.txt` is unchanged by design; both files are already picked up via GitHub-URL links from the docs tree.

## Pre-merge checklist

- [x] PR is **one intent** — governance update for topic + label curation.
- [ ] All CI checks green — pending (lychee + codeql only; no code changed).
- [x] Linked issue — none (housekeeping).
- [x] Migrations — n/a.
- [x] Public API changes — n/a.
- [x] Breaking changes — none.
- [x] No new dependency — none.
- [x] No outdated code left behind — none.
- [x] **Light AND dark mode verified** — n/a.
- [x] **Accessibility verified** — n/a.
- [x] Security — topic names are public metadata; nothing sensitive.
- [x] Performance — n/a.
- [x] Commits **GPG-signed** by Pratiyush — verified.
- [ ] Reviewer has read every changed line — pending reviewer.
- [x] **Docs updated** — the canonical topic + label reference now lives in steering, cross-linked from CLAUDE.md rule #11.