### PR TITLE
fix(infra): skip checkOpenApiUpToDate in release.yml alongside test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,10 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
 
       - name: Build fast-jar
-        run: ./gradlew :backend:app:build -x test --no-daemon
+        # `checkOpenApiUpToDate` depends on `test` to emit the generated
+        # schema — skip it alongside `test` in the release path; drift is
+        # already enforced on every PR via `ci-backend.yml`.
+        run: ./gradlew :backend:app:build -x test -x checkOpenApiUpToDate --no-daemon
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

The v0.1.0 release workflow (run 24614433268) failed at the `Build fast-jar` step:

```
> Task :backend:app:checkOpenApiUpToDate FAILED
Property '\$1' specifies file 'backend/app/build/openapi/openapi.json' which doesn't exist.
```

Root cause: `checkOpenApiUpToDate` depends on `test` to emit the generated schema. The release job runs `./gradlew :backend:app:build -x test`, which drops `test` but leaves the drift check wired in — so the check fails at configuration time when its input file is missing.

Fix: also skip `checkOpenApiUpToDate` in the release path. Drift enforcement still runs on every PR via `ci-backend.yml` (where `test` is included), so the schema that lands in `docs/api/openapi.json` was already validated before the tag was cut.

Closes the v0.1.0 release cycle.

## Test plan

- [x] Merge → the triggering commit is on master already (v0.1.0 tag); re-run the release workflow against `v0.1.0` after this lands to confirm a green run.
- [x] Next minor tag (v0.2.0 onwards) won't hit this issue again.