### PR TITLE
fix(infra): include buildSrc + gradlew in backend Dockerfiles

### DIFF
--- a/infra/docker/backend.Dockerfile
+++ b/infra/docker/backend.Dockerfile
@@ -15,9 +15,13 @@ ARG JAVA_VERSION=21
 FROM gradle:8.10-jdk${JAVA_VERSION} AS build
 WORKDIR /workspace
 
-# Cache dependencies first
+# Cache dependencies first. `buildSrc/` houses the precompiled-script
+# convention plugin `translately.quarkus-module` applied by every
+# backend subproject — without it, Gradle fails at plugin resolution
+# during `quarkusBuild`.
 COPY settings.gradle.kts build.gradle.kts gradle.properties* ./
 COPY gradle ./gradle
+COPY buildSrc ./buildSrc
 COPY backend ./backend
 RUN --mount=type=cache,target=/home/gradle/.gradle \
     gradle :backend:app:quarkusBuild -x test --no-daemon --stacktrace

--- a/infra/docker/backend.native.Dockerfile
+++ b/infra/docker/backend.native.Dockerfile
@@ -16,6 +16,8 @@ RUN microdnf install -y findutils \
 
 COPY settings.gradle.kts build.gradle.kts gradle.properties* ./
 COPY gradle ./gradle
+COPY gradlew ./
+COPY buildSrc ./buildSrc
 COPY backend ./backend
 
 # Use Gradle wrapper committed to the repo (added in the Gradle skeleton PR).


### PR DESCRIPTION
## Summary

The v0.1.0 release workflow's `build + push images` job fails inside the Docker build with:

```
Plugin [id: 'translately.quarkus-module'] was not found in any of the following sources
```

Cause: both `backend.Dockerfile` and `backend.native.Dockerfile` copy `settings.gradle.kts`, `gradle/`, and `backend/` into the build stage, but they miss `buildSrc/` — the precompiled-script convention plugin applied by every backend subproject lives there. Without it, Gradle fails at plugin resolution and the image never builds.

Also copy `gradlew` into the native Dockerfile (it shells out to `./gradlew` rather than the image's own `gradle` CLI).

Unblocks the GHCR image push for v0.1.0 and every subsequent signed tag.

## Test plan

- [x] Local sanity: the convention plugin files live under `buildSrc/src/main/kotlin/`; adding the COPY line matches what every non-container Gradle invocation (CI, local `./gradlew`) already assumes.
- [ ] After merge, re-tag v0.1.0 (or push a patch tag) so `release.yml` re-fires with the fix in context.

## Follow-up

No other workflow pulls `buildSrc/` either — but the regular backend CI workflow (`ci-backend.yml`) runs on the host, not inside the release Docker build, so it wasn't affected.