### PR TITLE
fix(backend): populate SecurityScopes from typed JWT scope claim (#151)

### DIFF
--- a/backend/api/src/main/kotlin/io/translately/api/security/JwtSecurityScopesFilter.kt
+++ b/backend/api/src/main/kotlin/io/translately/api/security/JwtSecurityScopesFilter.kt
@@ -29,6 +29,19 @@ import org.eclipse.microprofile.jwt.JsonWebToken
  * correct UX — the refresh flow lives at a single `/auth/refresh` endpoint
  * that doesn't go through this authenticator.
  *
+ * ### Claim reading
+ *
+ * Claims are read with a **typed `String` generic** (`getClaim<String>(...)`)
+ * rather than `getClaim<Any?>(...)?.toString()`. Smallrye stores JSON string
+ * claims as `jakarta.json.JsonString` internally, and calling `.toString()`
+ * on a `JsonString` yields the quoted JSON literal (e.g. `"access"` with the
+ * quote characters included) rather than the underlying value. That broke
+ * the `typ != "access"` short-circuit (every access token looked like a
+ * refresh token) and the `scope` parser (every scope string came back empty)
+ * — see issue #151. The typed generic makes smallrye unwrap via its internal
+ * converter. We also belt-and-braces strip a leading/trailing `"` pair from
+ * the raw result in case any stray caller still hands us a quoted string.
+ *
  * Runs at `Priorities.AUTHENTICATION` so `ScopeAuthorizationFilter` at
  * `AUTHORIZATION` sees the populated bag.
  */
@@ -50,18 +63,38 @@ class JwtSecurityScopesFilter(
         if (token.subject.isNullOrBlank()) return
 
         // Refresh tokens are forbidden as bearer credentials.
-        val tokenType = token.getClaim<Any?>(JwtClaims.TYPE)?.toString()
+        val tokenType = readStringClaim(token, JwtClaims.TYPE)
         if (tokenType != JwtClaims.TYPE_ACCESS) return
 
         // Prefer the "scope" string claim; fall back to JWT "groups" which
         // smallrye-jwt populates from .groups() on the issuer side. Both
         // should agree for tokens we issue ourselves, but belt-and-braces.
-        val scopeClaim = token.getClaim<Any?>(JwtClaims.SCOPE)?.toString()
+        val scopeClaim = readStringClaim(token, JwtClaims.SCOPE)
         val fromScope = Scope.parse(scopeClaim)
         val fromGroups = token.groups.mapNotNull { Scope.fromToken(it) }.toSet()
         val parsed = fromScope + fromGroups
         if (parsed.isNotEmpty()) {
             securityScopes.grantAll(securityScopes.granted + parsed)
+        }
+    }
+
+    /**
+     * Read [claim] as a `String`, asking smallrye-jwt for the underlying
+     * type via the typed generic. Defensively strips a single pair of
+     * wrapping double-quotes if present — covers the `JsonString.toString()`
+     * quoting regression from issue #151 even if another code path ever
+     * hands us a pre-quoted claim.
+     */
+    private fun readStringClaim(
+        token: JsonWebToken,
+        claim: String,
+    ): String? {
+        val raw = runCatching { token.getClaim<String>(claim) }.getOrNull() ?: return null
+        val trimmed = raw.trim()
+        return if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+            trimmed.substring(1, trimmed.length - 1)
+        } else {
+            trimmed
         }
     }
 }

--- a/backend/app/src/test/kotlin/io/translately/app/auth/AuthResourceIT.kt
+++ b/backend/app/src/test/kotlin/io/translately/app/auth/AuthResourceIT.kt
@@ -139,6 +139,45 @@ open class AuthResourceIT {
     }
 
     @Test
+    fun `login access token opens a scope-protected endpoint end-to-end (issue #151)`() {
+        // Full round-trip: signup → verify → login → hit a @RequiresScope
+        // endpoint with the real access JWT. Proves `JwtSecurityScopesFilter`
+        // reads the `scope` claim correctly and grants it to SecurityScopes.
+        // Uses the probe resource declared in JwtAuthenticationIT
+        // (`/test/jwt/projects`, requires Scope.PROJECTS_READ) — login issues
+        // `ORG_READ + PROJECTS_READ` by default, so this must return 200.
+        val email = uniqueEmail()
+        given()
+            .contentType(ContentType.JSON)
+            .body("""{"email":"$email","password":"correcthorsestaple!","fullName":"Jamie"}""")
+            .`when`()
+            .post("/api/v1/auth/signup")
+            .then()
+            .statusCode(201)
+        testHelpers.markVerified(email)
+
+        val accessToken =
+            given()
+                .contentType(ContentType.JSON)
+                .body("""{"email":"$email","password":"correcthorsestaple!"}""")
+                .`when`()
+                .post("/api/v1/auth/login")
+                .then()
+                .statusCode(200)
+                .extract()
+                .jsonPath()
+                .getString("accessToken")
+
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .get("/test/jwt/projects")
+            .then()
+            .statusCode(200)
+            .body(equalTo("ok-projects.read"))
+    }
+
+    @Test
     fun `verify-email returns 400 TOKEN_INVALID for garbage`() {
         given()
             .contentType(ContentType.JSON)

--- a/backend/app/src/test/kotlin/io/translately/app/credentials/PatResourceIT.kt
+++ b/backend/app/src/test/kotlin/io/translately/app/credentials/PatResourceIT.kt
@@ -19,13 +19,13 @@ import org.junit.jupiter.api.Test
  * End-to-end test for the PAT surface (T110).
  *
  * PATs require only `@Authenticated`; every user manages their own
- * credentials. The scope-intersection rule still applies at mint time
- * and is exercised here via the `X-Test-Scopes` header lifting the
- * caller's effective scope set (the same pattern `ApiKeyResourceIT`
- * uses). We mint a real JWT so `@Authenticated` is satisfied, but the
- * service-level intersection is driven by `TestScopeHeaderFilter` —
- * real per-org membership-to-scope mapping lands later in the phase and
- * will replace the header once it does.
+ * credentials. The scope-intersection rule still applies at mint time:
+ * requested PAT scopes must be a subset of the caller's effective scope
+ * set, which after the issue #151 fix is driven purely by the access
+ * JWT's `scope` claim. Tests mint a JWT with `keys.read` in its scope
+ * set and exercise the full `JwtSecurityScopesFilter` → `SecurityScopes`
+ * → `PatService` path — the `X-Test-Scopes` workaround previously needed
+ * here (see issue #151) is no longer required.
  */
 @QuarkusTest
 @QuarkusTestResource(value = PostgresAndMailpitResource::class, restrictToAnnotatedClass = true)
@@ -36,7 +36,14 @@ open class PatResourceIT {
     @Inject
     lateinit var jwtIssuer: JwtIssuer
 
-    /** JWT subject is the acting user's ULID — stable identity for /users/me. */
+    /**
+     * JWT subject is the acting user's ULID — stable identity for /users/me.
+     *
+     * The scope set deliberately carries `keys.read` so the happy-path mint
+     * below can request that scope without tripping `SCOPE_ESCALATION`.
+     * Org-admin scopes (e.g. `api-keys.write`) are left out so the escalation
+     * test can still cover the rejection path with a real JWT.
+     */
     private fun seedToken(): Pair<String, String> {
         val email = "pat-it-${System.nanoTime()}@example.com"
         val uid = helpers.seedVerifiedUser(email)
@@ -45,7 +52,7 @@ open class PatResourceIT {
                 .issue(
                     userExternalId = uid,
                     email = email,
-                    scopes = setOf(Scope.ORG_READ, Scope.PROJECTS_READ),
+                    scopes = setOf(Scope.ORG_READ, Scope.PROJECTS_READ, Scope.KEYS_READ),
                 ).accessToken
         return token to uid
     }
@@ -54,11 +61,10 @@ open class PatResourceIT {
     fun `mint → list → revoke happy path`() {
         val (token, _) = seedToken()
 
-        // mint — caller holds keys.read via X-Test-Scopes; PAT requests keys.read.
+        // mint — caller's JWT carries keys.read; PAT requests keys.read.
         val mintResp =
             given()
                 .header("Authorization", "Bearer $token")
-                .header("X-Test-Scopes", Scope.KEYS_READ.token)
                 .contentType(ContentType.JSON)
                 .body(
                     """
@@ -116,8 +122,7 @@ open class PatResourceIT {
         val (token, _) = seedToken()
         given()
             .header("Authorization", "Bearer $token")
-            // Caller holds keys.read only; asking for api-keys.write must 403.
-            .header("X-Test-Scopes", Scope.KEYS_READ.token)
+            // Caller's JWT carries keys.read only; asking for api-keys.write must 403.
             .contentType(ContentType.JSON)
             .body(
                 """
@@ -139,7 +144,6 @@ open class PatResourceIT {
         val (token, _) = seedToken()
         given()
             .header("Authorization", "Bearer $token")
-            .header("X-Test-Scopes", Scope.KEYS_READ.token)
             .contentType(ContentType.JSON)
             .body(
                 """
@@ -176,7 +180,6 @@ open class PatResourceIT {
         val patId =
             given()
                 .header("Authorization", "Bearer $tokenA")
-                .header("X-Test-Scopes", Scope.KEYS_READ.token)
                 .contentType(ContentType.JSON)
                 .body("""{"name":"A","scopes":["keys.read"]}""")
                 .`when`()

--- a/backend/app/src/test/kotlin/io/translately/app/security/JwtSecurityScopesFilterIT.kt
+++ b/backend/app/src/test/kotlin/io/translately/app/security/JwtSecurityScopesFilterIT.kt
@@ -1,0 +1,154 @@
+package io.translately.app.security
+
+import io.quarkus.security.Authenticated
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured.given
+import io.translately.security.RequiresScope
+import io.translately.security.Scope
+import io.translately.security.jwt.JwtIssuer
+import jakarta.annotation.security.PermitAll
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import org.hamcrest.Matchers.contains
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression test for issue #151.
+ *
+ * Exercises [io.translately.api.security.JwtSecurityScopesFilter] end-to-end
+ * by minting a real access JWT via [JwtIssuer] and presenting it against a
+ * probe endpoint guarded by `@RequiresScope`. The fix replaces
+ * `getClaim<Any?>(...)?.toString()` with a typed `getClaim<String>(...)`
+ * read — `JsonString.toString()` returned a quoted JSON literal (e.g.
+ * `"access"` including the quote characters), breaking the `typ` check and
+ * the `scope` parser. Before the fix these tests were intermittent: any
+ * token reaching the filter as a `JsonString` produced a 403 with empty
+ * `SecurityScopes.granted` rather than the expected 200.
+ *
+ * Tests live under `io.translately.app.*` so OpenAPI scanning (restricted
+ * to `io.translately.api`) never catalogues the probe resource into the
+ * committed `docs/api/openapi.json`.
+ */
+@QuarkusTest
+class JwtSecurityScopesFilterIT {
+    @Inject
+    lateinit var issuer: JwtIssuer
+
+    @Test
+    fun `valid JWT with the required scope reaches a protected endpoint (200)`() {
+        val jwt =
+            issuer
+                .issue(
+                    userExternalId = "01HT7F8KXN0GZJYQP3M5JWTSCP1",
+                    email = "scopes-filter@example.com",
+                    scopes = setOf(Scope.PROJECTS_READ),
+                ).accessToken
+
+        given()
+            .header("Authorization", "Bearer $jwt")
+            .`when`()
+            .get("/test/scopes-filter/projects")
+            .then()
+            .statusCode(200)
+            .body(equalTo("projects.read"))
+    }
+
+    @Test
+    fun `valid JWT without the required scope yields 403 INSUFFICIENT_SCOPE`() {
+        val jwt =
+            issuer
+                .issue(
+                    userExternalId = "01HT7F8KXN0GZJYQP3M5JWTSCP2",
+                    email = "scopes-filter@example.com",
+                    scopes = setOf(Scope.ORG_READ),
+                ).accessToken
+
+        given()
+            .header("Authorization", "Bearer $jwt")
+            .`when`()
+            .get("/test/scopes-filter/projects")
+            .then()
+            .statusCode(403)
+            .body("error.code", equalTo("INSUFFICIENT_SCOPE"))
+            .body("error.details.missing", contains("projects.read"))
+    }
+
+    @Test
+    fun `JWT carrying multiple scopes grants every one to SecurityScopes`() {
+        // Token carries projects.read AND keys.read — both probes must pass.
+        val jwt =
+            issuer
+                .issue(
+                    userExternalId = "01HT7F8KXN0GZJYQP3M5JWTSCP3",
+                    email = "scopes-filter@example.com",
+                    scopes = setOf(Scope.PROJECTS_READ, Scope.KEYS_READ),
+                ).accessToken
+
+        given()
+            .header("Authorization", "Bearer $jwt")
+            .`when`()
+            .get("/test/scopes-filter/projects")
+            .then()
+            .statusCode(200)
+        given()
+            .header("Authorization", "Bearer $jwt")
+            .`when`()
+            .get("/test/scopes-filter/keys")
+            .then()
+            .statusCode(200)
+    }
+
+    @Test
+    fun `refresh token presented as a bearer credential is refused (403)`() {
+        // Refresh tokens carry typ=refresh; the filter short-circuits and
+        // grants nothing, so the downstream scope check 403s.
+        val tokens =
+            issuer.issue(
+                userExternalId = "01HT7F8KXN0GZJYQP3M5JWTSCP4",
+                email = "scopes-filter@example.com",
+                scopes = setOf(Scope.PROJECTS_READ),
+            )
+        given()
+            .header("Authorization", "Bearer ${tokens.refreshToken}")
+            .`when`()
+            .get("/test/scopes-filter/projects")
+            .then()
+            .statusCode(403)
+    }
+
+    // ---- probe resource -----------------------------------------------------
+    //
+    // Test-only JAX-RS resource in `io.translately.app.*`. OpenAPI scanning
+    // is restricted to `io.translately.api` via `mp.openapi.scan.packages`,
+    // so this probe never contributes to the committed schema.
+
+    @Path("/test/scopes-filter")
+    @ApplicationScoped
+    @Suppress("FunctionOnlyReturningConstant")
+    class ScopesFilterProbe {
+        @GET
+        @Path("/open")
+        @Produces(MediaType.TEXT_PLAIN)
+        @PermitAll
+        fun open(): String = "open"
+
+        @GET
+        @Path("/projects")
+        @Produces(MediaType.TEXT_PLAIN)
+        @Authenticated
+        @RequiresScope(Scope.PROJECTS_READ)
+        fun projects(): String = "projects.read"
+
+        @GET
+        @Path("/keys")
+        @Produces(MediaType.TEXT_PLAIN)
+        @Authenticated
+        @RequiresScope(Scope.KEYS_READ)
+        fun keys(): String = "keys.read"
+    }
+}

--- a/backend/app/src/test/kotlin/io/translately/app/security/TestScopeHeaderFilter.kt
+++ b/backend/app/src/test/kotlin/io/translately/app/security/TestScopeHeaderFilter.kt
@@ -11,10 +11,20 @@ import jakarta.ws.rs.ext.Provider
 
 /**
  * Test-only authenticator: reads the space-separated `X-Test-Scopes` header
- * and grants the parsed [Scope] set into the request-scoped [SecurityScopes]
- * bean. Runs at `Priorities.AUTHENTICATION`, i.e. *before*
- * `ScopeAuthorizationFilter` (which runs at `AUTHORIZATION`) — the real Phase 1
- * JWT / API-key authenticators will replace this.
+ * and *unions* the parsed [Scope] set into the request-scoped
+ * [SecurityScopes] bean. Runs at `Priorities.AUTHENTICATION`, alongside the
+ * real `JwtSecurityScopesFilter`.
+ *
+ * ### Why union, not replace?
+ *
+ * `JwtSecurityScopesFilter` also runs at `AUTHENTICATION`. Ordering between
+ * request filters at the same priority is not deterministic in JAX-RS, so
+ * both filters treat `SecurityScopes` as additive — whichever runs second
+ * must not clobber what the first one granted. Previously this filter
+ * unconditionally called `grantAll(...)` (which clears then adds); when the
+ * header was absent that wiped out any JWT-granted scopes, intermittently
+ * causing 403 `INSUFFICIENT_SCOPE` on endpoints that should have passed.
+ * See issue #151. The filter now no-ops when the header is absent.
  */
 @Provider
 @Priority(Priorities.AUTHENTICATION)
@@ -23,8 +33,11 @@ class TestScopeHeaderFilter(
     private val scopes: SecurityScopes,
 ) : ContainerRequestFilter {
     override fun filter(requestContext: ContainerRequestContext) {
-        val header = requestContext.getHeaderString(HEADER)
-        scopes.grantAll(Scope.parse(header))
+        val header = requestContext.getHeaderString(HEADER) ?: return
+        val parsed = Scope.parse(header)
+        if (parsed.isNotEmpty()) {
+            scopes.grantAll(scopes.granted + parsed)
+        }
     }
 
     companion object {

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -71,6 +71,10 @@ The ledger is the only DB read on the hot path; it carries a `(jti UNIQUE, consu
 
 `JwtSecurityScopesFilter` deliberately rejects refresh tokens on regular endpoints — refresh tokens are only valid at the `/api/v1/auth/refresh` controller. This prevents a stolen refresh token from being used to read data directly; it also means the refresh TTL can be longer than the access TTL without compromising the API surface.
 
+### Claim reading
+
+`JwtSecurityScopesFilter` reads the `typ` and `scope` claims with a **typed `String` generic** — `token.getClaim<String>(name)` rather than `token.getClaim<Any?>(name)?.toString()`. Smallrye stores JSON string claims as `jakarta.json.JsonString` internally, and `JsonString.toString()` returns the quoted JSON literal (for example `"access"` with the quote characters included) rather than the underlying value. Reading through the typed generic makes Smallrye unwrap the claim via its internal converter and hand back the raw `String`. The filter additionally strips a leading/trailing `"` pair from the result as a belt-and-braces guard against any code path that still surfaces a quoted value. Root cause for [issue #151](https://github.com/Pratiyush/translately/issues/151); regression guarded by `JwtSecurityScopesFilterIT` (`:backend:app`).
+
 ## API key + PAT authentication
 
 Both credential types follow the same shape and Argon2id-hash their secrets:
@@ -110,6 +114,7 @@ PATs identify a **user**, so their scopes are intersected with the user's effect
 ## Test coverage
 
 - `JwtIssuerIT` / `JwtAuthenticationIT` (in `:backend:app`) — round-trip signed JWTs against a running Quarkus instance; assert every claim field and every rejection path.
+- `JwtSecurityScopesFilterIT` (`:backend:app`) — regression for [issue #151](https://github.com/Pratiyush/translately/issues/151): mints a JWT via `JwtIssuer`, presents it on a `@RequiresScope` probe endpoint, and asserts the filter unwraps `JsonString` claims correctly so `SecurityScopes.granted` is populated.
 - `PasswordHasherTest` (`:backend:security`) — verifies Argon2id parameter constants, round-trip hash+verify, wrong-password rejection, and malformed-hash graceful failure.
 - `CryptoServiceTest` — envelope layout, tamper detection, KEK-size validation.
 - `ScopeResolverTest` / `OrgRoleScopesTest` — role-to-scope mapping invariants.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1104,6 +1104,10 @@ The ledger is the only DB read on the hot path; it carries a `(jti UNIQUE, consu
 
 `JwtSecurityScopesFilter` deliberately rejects refresh tokens on regular endpoints — refresh tokens are only valid at the `/api/v1/auth/refresh` controller. This prevents a stolen refresh token from being used to read data directly; it also means the refresh TTL can be longer than the access TTL without compromising the API surface.
 
+### Claim reading
+
+`JwtSecurityScopesFilter` reads the `typ` and `scope` claims with a **typed `String` generic** — `token.getClaim<String>(name)` rather than `token.getClaim<Any?>(name)?.toString()`. Smallrye stores JSON string claims as `jakarta.json.JsonString` internally, and `JsonString.toString()` returns the quoted JSON literal (for example `"access"` with the quote characters included) rather than the underlying value. Reading through the typed generic makes Smallrye unwrap the claim via its internal converter and hand back the raw `String`. The filter additionally strips a leading/trailing `"` pair from the result as a belt-and-braces guard against any code path that still surfaces a quoted value. Root cause for [issue #151](https://github.com/Pratiyush/translately/issues/151); regression guarded by `JwtSecurityScopesFilterIT` (`:backend:app`).
+
 ## API key + PAT authentication
 
 Both credential types follow the same shape and Argon2id-hash their secrets:
@@ -1143,6 +1147,7 @@ PATs identify a **user**, so their scopes are intersected with the user's effect
 ## Test coverage
 
 - `JwtIssuerIT` / `JwtAuthenticationIT` (in `:backend:app`) — round-trip signed JWTs against a running Quarkus instance; assert every claim field and every rejection path.
+- `JwtSecurityScopesFilterIT` (`:backend:app`) — regression for [issue #151](https://github.com/Pratiyush/translately/issues/151): mints a JWT via `JwtIssuer`, presents it on a `@RequiresScope` probe endpoint, and asserts the filter unwraps `JsonString` claims correctly so `SecurityScopes.granted` is populated.
 - `PasswordHasherTest` (`:backend:security`) — verifies Argon2id parameter constants, round-trip hash+verify, wrong-password rejection, and malformed-hash graceful failure.
 - `CryptoServiceTest` — envelope layout, tamper detection, KEK-size validation.
 - `ScopeResolverTest` / `OrgRoleScopesTest` — role-to-scope mapping invariants.


### PR DESCRIPTION
## Summary

Fix the intermittent 403 `INSUFFICIENT_SCOPE` regression traced in issue #151. `JwtSecurityScopesFilter` was reading JWT claims as `getClaim<Any?>(...)?.toString()`, which surfaces `jakarta.json.JsonString` instances whose `toString()` includes the JSON quote characters (e.g. `"access"` with the literal `"` included). That broke both the `typ` access/refresh gate and the `scope` parser, leaving `SecurityScopes.granted` empty on every authenticated request.

A second failure mode lived in the test-only `TestScopeHeaderFilter` — it unconditionally called `grantAll(...)` (which clears-then-adds), so when the header was absent it wiped out whatever `JwtSecurityScopesFilter` had just granted. Both filters now union their grants; order between filters at the same priority no longer matters.

## Why

Root cause: `JsonString.toString()` returns the quoted JSON literal, so `tokenType != JwtClaims.TYPE_ACCESS` was always true and `Scope.parse("\"projects.read projects.write\"")` returned the empty set. Every `@RequiresScope` endpoint 403'd; tests that expected 2xx flaked, tests that expected 4xx passed — exactly the symptom that surfaced in #150. The workaround added to `PatResourceIT` in #150 (`X-Test-Scopes` header) papered over the issue; this PR removes that workaround now that the filter is trusted.

Closes #151

## How

- **`backend/api/src/main/kotlin/io/translately/api/security/JwtSecurityScopesFilter.kt`** — read `typ` and `scope` through a typed `String` generic so smallrye unwraps via its internal converter; new private `readStringClaim` helper also defensively strips a wrapping `"…"` pair in case a future path still surfaces a pre-quoted value. Class-level docstring expanded to document the regression.
- **`backend/app/src/test/kotlin/io/translately/app/security/JwtSecurityScopesFilterIT.kt`** — new `@QuarkusTest` covering the happy path (JWT with required scope → 200), the denial path (JWT without it → 403 + `INSUFFICIENT_SCOPE`), a multi-scope JWT hitting two independently-protected probes, and the refresh-token rejection. Probe resource lives under `io.translately.app.*` so OpenAPI scanning (scoped to `io.translately.api`) never catalogues it.
- **`backend/app/src/test/kotlin/io/translately/app/auth/AuthResourceIT.kt`** — adds the full signup → verify → login → `/test/jwt/projects` round-trip assertion requested in the issue acceptance criteria.
- **`backend/app/src/test/kotlin/io/translately/app/credentials/PatResourceIT.kt`** — reverts the `X-Test-Scopes` workaround. JWT now carries `KEYS_READ` directly so the filter's output is the only scope source the test relies on. Escalation + unknown-scope branches still exercise rejection against a real JWT.
- **`backend/app/src/test/kotlin/io/translately/app/security/TestScopeHeaderFilter.kt`** — no-op when header is absent; union when present. Previously it clobbered JWT scopes on the "no header" path. `ApiKeyResourceIT` still relies on the union semantics to layer elevated `api-keys.*` scopes on a login-level JWT.
- **`docs/architecture/auth.md`** — new "Claim reading" subsection under JWT format documenting the typed-generic pattern, the `JsonString.toString()` pitfall, and the regression guard; test-coverage section gains a line for `JwtSecurityScopesFilterIT`.
- **`docs/llms-full.txt`** — regenerated via `scripts/gen-llms-txt.sh`.

## Tests

- [x] Unit tests added / updated — new `JwtSecurityScopesFilterIT`, happy-path round-trip added to `AuthResourceIT`, `PatResourceIT` reworked to rely on the real filter.
- [x] Integration tests pass against Testcontainers — `./gradlew :backend:app:test :backend:app:checkOpenApiUpToDate ktlintCheck detekt` all green locally (OrbStack Docker socket). 94 integration tests pass.
- [x] Manual smoke-test described below

**Smoke notes:** ran the three acceptance suites individually to confirm behaviour, then the full `:backend:app:test` target. Key results:

- `JwtSecurityScopesFilterIT` — 4/4 pass (including the two that the buggy filter was failing).
- `AuthResourceIT` — 14/14 pass, including the new `login access token opens a scope-protected endpoint end-to-end` test.
- `PatResourceIT` — 5/5 pass without `X-Test-Scopes` (this is the proof the fix works end-to-end: the JWT's `scope` claim alone carries enough to mint a PAT).
- `ApiKeyResourceIT` — still passes with its `X-Test-Scopes` layering.
- `ScopeAuthorizationIT` — still passes (all 11 tests, including the "no header" denial paths).

## Docs

- ~~**Product**~~ — no user-visible behaviour change; filter is a backend-internal fix.
- [x] **Architecture** — `docs/architecture/auth.md` updated with a "Claim reading" subsection + regression-test reference.
- ~~**API**~~ — no new error codes or endpoint changes; `docs/api/openapi.json` unchanged (verified via `checkOpenApiUpToDate`).
- ~~**Self-hosting**~~ — no env vars, migrations, or operator-facing knobs touched.
- [x] **LLM-ingestible** — `docs/llms-full.txt` regenerated with `scripts/gen-llms-txt.sh`.

## Pre-merge checklist

- [x] PR is **one intent** (fix the JWT scope propagation regression; no mixed concerns)
- [ ] All CI checks green (backend, webapp, e2e, link checker, lint, security scan) — pending CI
- [x] Linked issue closed by `Closes #151`
- [x] Migrations are forward-compatible — no schema changes
- [ ] Public API changes documented in `CHANGELOG.md` — n/a, internal bug fix with no API shape change
- [x] Breaking changes labeled `type:breaking` — n/a, not breaking
- [x] No new dependency without justification — no new deps
- [x] No outdated code left behind
- [x] **Light AND dark mode verified** — n/a, backend-only change
- [x] **Accessibility verified** — n/a, backend-only change
- [x] Security: no secrets, no SQL injection, validation at boundaries — filter hardening, no new secrets or SQL
- [x] Performance: no N+1 queries introduced — filter is O(1), same shape as before
- [x] Commits **GPG-signed** by Pratiyush, no AI co-author trailers
- [x] **Docs updated** per the `## Docs` section above