### PR TITLE
fix(infra): clear stale draft releases before create in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,6 +215,23 @@ jobs:
                 -czf translately-webapp-${{ needs.verify.outputs.version }}.tar.gz .
           fi
 
+      # Delete any leftover draft release that shares this tag so the
+      # softprops action doesn't hit "already_exists" on a second run.
+      # The v0.1.0 tag retry surfaced this: a failed first run left a
+      # draft behind and every subsequent attempt refused to update it
+      # because two releases pointed at the same tag.
+      - name: Clear stale draft release for this tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ needs.verify.outputs.version }}"
+          DRAFT_IDS=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+            --jq ".[] | select(.tag_name == \"${TAG}\" and .draft == true) | .id")
+          for id in ${DRAFT_IDS}; do
+            echo "Deleting stale draft release ${id} (tag ${TAG})"
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/releases/${id}"
+          done
+
       - name: Create / update GitHub Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary

When a release-workflow run dies between the "Create GitHub Release" step and its dependents (images, sign, etc.), a draft release for the tag lingers. The next tag push then hits `Validation Failed: already_exists` from `softprops/action-gh-release` even though no published release exists — two releases point at the same tag, and the action can't pick which to update.

Shipped during the v0.1.0 re-tag recovery: the first release run failed mid-pipeline on an unrelated Dockerfile issue (`buildSrc` missing from the image build context, fixed in #161) and left a draft behind. Every subsequent re-run blocked on `already_exists` until I manually ran:

```sh
gh api repos/Pratiyush/translately/releases --jq '.[] | select(.tag_name == "v0.1.0") | .id'
gh api -X DELETE repos/Pratiyush/translately/releases/<draft_id>
```

## Fix

Bake the cleanup into the workflow. A new step immediately before `softprops/action-gh-release` enumerates draft releases for the current tag via the REST API and deletes them. No-op on the happy path.

```yaml
- name: Clear stale draft release for this tag
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  run: |
    TAG="v${{ needs.verify.outputs.version }}"
    DRAFT_IDS=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
      --jq ".[] | select(.tag_name == \"${TAG}\" and .draft == true) | .id")
    for id in ${DRAFT_IDS}; do
      echo "Deleting stale draft release ${id} (tag ${TAG})"
      gh api -X DELETE "repos/${GITHUB_REPOSITORY}/releases/${id}"
    done
```

## Test plan

- [x] YAML parses (syntax verified)
- [ ] Next phase tag (v0.2.0) exercises the happy path — no drafts, cleanup is a no-op, release creates cleanly
- [ ] If a future run fails mid-release and leaves a draft, the next push auto-recovers