### PR TITLE
fix(docs): publish screenshots.md at /product/screenshots.html

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3390,6 +3390,12 @@ First shipped in [v0.1.0](../../CHANGELOG.md) under T118 (orgs UI) + T119 (proje
 title: Screenshots
 parent: Product
 nav_order: 99
+# Override the site-wide `permalink: pretty`. Without this, the page's
+# default URL would be `/product/screenshots/` — the exact same path as
+# the `docs/product/screenshots/` PNG directory, which wins the collision
+# and leaves the page unpublished. Use `.html` instead so the two
+# siblings don't fight for the same URL.
+permalink: /product/screenshots.html
 ---
 
 # Screenshots

--- a/docs/product/screenshots.md
+++ b/docs/product/screenshots.md
@@ -2,6 +2,12 @@
 title: Screenshots
 parent: Product
 nav_order: 99
+# Override the site-wide `permalink: pretty`. Without this, the page's
+# default URL would be `/product/screenshots/` — the exact same path as
+# the `docs/product/screenshots/` PNG directory, which wins the collision
+# and leaves the page unpublished. Use `.html` instead so the two
+# siblings don't fight for the same URL.
+permalink: /product/screenshots.html
 ---
 
 # Screenshots


### PR DESCRIPTION
## Summary

`https://pratiyush.github.io/translately/product/screenshots.html` 404'd on the live site (reported by @Pratiyush in session review).

Root cause: in PR #164 I added per-page `permalink: /product/<name>.html` to the three screenshot-embedding product pages, but missed `screenshots.md`. Under Jekyll's site-wide `permalink: pretty`, `docs/product/screenshots.md` wanted to render at `/product/screenshots/` — the **same path** the `docs/product/screenshots/` PNG directory already occupies. Jekyll silently dropped the collision (directory wins, page unpublished).

Fix: add the override so the sibling file and directory don't fight for the same URL.

```yaml
permalink: /product/screenshots.html
```

Existing Markdown links of the form `[Screenshots](screenshots.md)` (e.g. in `docs/product/README.md`) still resolve because Jekyll rewrites `.md` links to the target file's permalink — no other edits needed.

## Test plan

- [x] Before: `curl -I /product/screenshots.html` → 404
- [ ] After merge + Pages redeploy: same URL returns 200 and the capture-workflow content renders
- [x] `docs/llms-full.txt` regenerated

## Follow-up

Phase 1 is fully closed — every Phase 1 milestone issue is merged. Nothing else is pending for the v0.1.0 scope; the next phase (v0.2.0: translation keys + ICU + JSON round-trip) starts clean on Phase 2 tickets (#X…).