### PR TITLE
fix(backend): activate Hibernate + Flyway in %dev and %prod profiles

### DIFF
--- a/backend/app/src/main/resources/application.yml
+++ b/backend/app/src/main/resources/application.yml
@@ -99,8 +99,11 @@ quarkus:
       json: true
 
   # Datasource / JPA / Flyway are on the classpath via the :backend:data module.
-  # For Phase 0 there are no entities and no migrations; keep them inactive so the
-  # app boots without a running database. Each profile enables them as needed.
+  # The default block ships `active: false` so the classpath stays inert for
+  # tooling-only tasks (e.g. `./gradlew :backend:app:quarkusGenerateCode`,
+  # schema-only smoke probes) that don't want a database on the other end.
+  # Every runtime profile (%dev, %test, %prod) overrides these to `true` so
+  # real use always boots against Postgres — see the per-profile blocks below.
   datasource:
     db-kind: postgresql
     devservices:
@@ -133,6 +136,14 @@ quarkus:
       category:
         "io.translately":
           level: DEBUG
+    # Re-enable the JPA + migrations layer that the Phase 0 default
+    # block turned off. Every phase since v0.1.0 ships real entities +
+    # Flyway migrations, so quarkusDev needs both active.
+    hibernate-orm:
+      active: true
+    flyway:
+      active: true
+      migrate-at-start: true
     datasource:
       # docker compose up -d brings this up at localhost:5432
       username: translately
@@ -178,6 +189,15 @@ quarkus:
   quarkus:
     log:
       level: INFO
+    # Re-enable the JPA + migrations layer that the Phase 0 default
+    # block turned off. Production deploys rely on Flyway to apply
+    # V1..V4 (and future migrations) at boot so a fresh Postgres lands
+    # at a consistent schema.
+    hibernate-orm:
+      active: true
+    flyway:
+      active: true
+      migrate-at-start: true
     datasource:
       username: ${QUARKUS_DATASOURCE_USERNAME}
       password: ${QUARKUS_DATASOURCE_PASSWORD}


### PR DESCRIPTION
## Summary
- `quarkusDev` has been silently broken since v0.1.0 shipped: Hibernate ORM + Flyway are forced off by the Phase 0 default, and neither `%dev` nor `%prod` re-enable them.
- Two-line override in each of the two profile blocks. Default-block stays off so tooling-only Gradle tasks (codegen, schema probes) still boot without a DB.
- CI passed because tests use `@QuarkusTestResource` with their own datasource config.

## Closes
- #180

## What this fixes

Before:
```
INFO  JPAConfig  Hibernate ORM persistence unit '<default>' was deactivated
WARN  agroal     FATAL: role "translately" does not exist
DOWN  health     Database connections health check
```

After (expected on a fresh `docker compose up -d && ./gradlew :backend:app:quarkusDev`):
```
INFO  Flyway     Successfully applied 4 migrations (V1..V4)
INFO  JPAConfig  Hibernate ORM persistence unit '<default>' activated
UP    health     Database connections health check
UP    health     Redis connection health check
```

## Test plan
- [x] `./gradlew :backend:app:compileKotlin :backend:app:ktlintCheck` — clean locally
- [ ] CI: `build + test` suite stays green (IT suites self-configure via `@QuarkusTestResource`; they don't read the default datasource)
- [ ] Manual verification after merge: `docker compose up -d && ./gradlew :backend:app:quarkusDev`, check `curl http://localhost:8080/q/health` reports UP for DB

## Docs
`docs/self-hosting/runtime-profiles.md` already claimed (post-PR-#178) "Hibernate ORM is active; Flyway runs migrations on boot." The code now matches the doc.

## Pre-merge
- [x] GPG-signed commits (author = Pratiyush)
- [x] Conventional Commits title
- [x] One intent: re-activate Hibernate + Flyway in runtime profiles
- [x] Surgical diff: only `application.yml`, only the three override lines per profile + a comment tweak
- [x] **I have read and accept the [Contributor License Agreement](../blob/master/CLA.md).**

## Follow-up (out of scope for this PR)
- Add a boot-sanity CI step that hits `/q/health` after `quarkus:build` so this class of regression can't hide behind the test-only datasource config again. Will open a separate ticket.

Closes #180